### PR TITLE
document new search API

### DIFF
--- a/docs/api-reference/v4/endpoints/global-search.mdx
+++ b/docs/api-reference/v4/endpoints/global-search.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Global Search"
+title: "Search (new)"
 api: "POST https://api.flare.io/firework/v4/events/global/_search"
 ---
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -171,7 +171,8 @@
         },
         {
           "group": "Global Search",
-          "pages": [
+          "pages": [ 
+            "api-reference/v4/endpoints/global-search",
             "api-reference/v2/endpoints/search/get-search",
             "api-reference/v2/endpoints/search/post-search"
           ]


### PR DESCRIPTION
I will move the existing search endpoints to "Deprecated APIs" in a follow-up PR when we release the new search guide.