### PR TITLE
remove ad,ads search types from flare docs

### DIFF
--- a/docs/api-reference/spec/firework-v2-openapi.json
+++ b/docs/api-reference/spec/firework-v2-openapi.json
@@ -6468,7 +6468,6 @@
                                 "blog_post",
                                 "seller",
                                 "forum_profile",
-                                "ad",
                                 "bot",
                                 "stealer_log"
                             ],
@@ -7651,8 +7650,6 @@
                                 "bucket",
                                 "bucket_object",
                                 "whois",
-                                "ad",
-                                "ads",
                                 "experimental"
                             ],
                             "example": "attachment",

--- a/docs/api-reference/spec/firework-v2-swagger.json
+++ b/docs/api-reference/spec/firework-v2-swagger.json
@@ -747,7 +747,6 @@
               "blog_post",
               "seller",
               "forum_profile",
-              "ad",
               "bot",
               "stealer_log"
             ],
@@ -2035,8 +2034,6 @@
               "bucket",
               "bucket_object",
               "whois",
-              "ad",
-              "ads",
               "experimental"
             ],
             "example": "attachment",

--- a/docs/api-reference/spec/firework-v3-openapi.json
+++ b/docs/api-reference/spec/firework-v3-openapi.json
@@ -2063,8 +2063,6 @@
                                 "bucket",
                                 "bucket_object",
                                 "whois",
-                                "ad",
-                                "ads",
                                 "experimental"
                             ],
                             "example": "attachment",

--- a/docs/api-reference/spec/firework-v3-swagger.json
+++ b/docs/api-reference/spec/firework-v3-swagger.json
@@ -376,8 +376,6 @@
               "bucket",
               "bucket_object",
               "whois",
-              "ad",
-              "ads",
               "experimental"
             ],
             "example": "attachment",


### PR DESCRIPTION
As part of an on-call issue: https://gitlab.com/flaresystems/pyro/-/work_items/2769, we should remove any mention of the ad/ads search type in the Flare docs.