### PR TITLE
docs: page for unpublished entries, sdk changelog

### DIFF
--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -3,12 +3,30 @@ title: "Flare API Updates"
 description: "New updates and improvements"
 ---
 
+{/*
+NOTE: See `overview_unpublished.mdx` for changes that are not yet published.
+*/}
+
 <Note>
 This page lists changes to Flare's API.
 Release notes for the Flare Platform can be found on the [product documentation website](https://docs.flare.io/releases).
 </Note>
 
-<Update label="2024-09" description="September 2024">
+<Update label="2024-10-22" description="Python SDK - v0.1.25">
+  Released version 0.1.25 of the
+  [Python SDK](/sdk/python).
+
+  This release fixes an issue with packaging that caused the Python SDK to
+  declare too many Python dependencies, conflicting with libraries installed
+  in the environments of some users.
+
+  The following command can be used to upgrade:
+  ```shell
+  pip install flareio>=0.1.25
+  ```
+</Update>
+
+<Update label="2024-09" description="API - September 2024">
   The API documentation has been revamped for better clarity and structure.
 
   We’ve added new [use-case guides](/introduction/getting-started)

--- a/docs/changelog/overview_unpublished.mdx
+++ b/docs/changelog/overview_unpublished.mdx
@@ -1,0 +1,11 @@
+---
+title: "Flare API Updates - Unpublished"
+---
+
+{/*
+NOTE: This contains unpublished entries for `overview.mdx`.
+You may view this page at changelog/overview_wip
+*/}
+
+This page contains Work-In-Progress entries for the
+[changelog](/changelog/overview).


### PR DESCRIPTION
- Create a new page for unpublished entries, as almost-suggested by @fxleblanc. Note that we would only put stuff here that we think is fine to be public (99% of things).
- Add a release note for the last version of the SDK. My main goal was to "set an example" so that our patern for distinguishing SDK and API version updates is clear.
