### PR TITLE
Add quotas information

### DIFF
--- a/docs/api-reference/v2/endpoints/search/get-search.mdx
+++ b/docs/api-reference/v2/endpoints/search/get-search.mdx
@@ -2,3 +2,7 @@
 title: "Search"
 openapi: firework-v2-openapi get /search/
 ---
+
+import GlobalSearchApiQuotaNote from '/snippets/global-search-api-quota-note.mdx';
+
+<GlobalSearchApiQuotaNote />

--- a/docs/api-reference/v2/endpoints/search/post-search.mdx
+++ b/docs/api-reference/v2/endpoints/search/post-search.mdx
@@ -2,3 +2,7 @@
 openapi: firework-v2-openapi post /search/
 title: Search
 ---
+
+import GlobalSearchApiQuotaNote from '/snippets/global-search-api-quota-note.mdx';
+
+<GlobalSearchApiQuotaNote />

--- a/docs/api-reference/v4/endpoints/global-search.mdx
+++ b/docs/api-reference/v4/endpoints/global-search.mdx
@@ -4,5 +4,7 @@ api: "POST https://api.flare.io/firework/v4/events/global/_search"
 ---
 
 import EventSearchCommon from '/snippets/endpoint-event-search-common.mdx';
+import GlobalSearchApiQuotaNote from '/snippets/global-search-api-quota-note.mdx';
 
+<GlobalSearchApiQuotaNote />
 <EventSearchCommon />

--- a/docs/concepts/rate-limits-and-quotas.mdx
+++ b/docs/concepts/rate-limits-and-quotas.mdx
@@ -1,7 +1,8 @@
 ---
-title: 'Rate Limits'
+title: 'Rate Limits and Quotas'
 ---
 
+## Rate Limits
 
 API usage exceeding 1 request per second is subject to Flare's API rate limit.
 Rate Limits are enforced **per organization**.
@@ -22,3 +23,11 @@ If you receive 429 errors, Flare's recommended course of action is to wait 10 se
 ```
 
 </ResponseExample>
+
+
+## Quotas
+API users are responsible for monitoring their Global Search API usage and ensuring it remains within their allocated monthly quota.
+  
+Each response includes `X-Flare-Global-Searches-Remaining`: The number of API calls remaining in your monthly allocation.
+
+To avoid service interruptions or missed events, we recommend implementing proactive monitoring of your usage.

--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -12,7 +12,7 @@ The Flare API can be used to access Flare's search capabilities, configure monit
     Create an API Key and obtain API tokens.
   </Card>
 
-  <Card title="Rate Limits" icon="gauge-high" href="/concepts/rate-limits">
+  <Card title="Rate Limits" icon="gauge-high" href="/concepts/rate-limits-and-quotas">
     Learn about the Flare API's rate limits.
   </Card>
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -91,7 +91,7 @@
       "group": "Base Concepts",
       "pages": [
         "concepts/authentication",
-        "concepts/rate-limits",
+        "concepts/rate-limits-and-quotas",
         "concepts/errors",
         "concepts/paging"
       ]

--- a/docs/snippets/global-search-api-quota-note.mdx
+++ b/docs/snippets/global-search-api-quota-note.mdx
@@ -1,0 +1,3 @@
+<Note>
+This endpoint is subject to quotas, [read more here <Icon icon="book" size={16} />](/concepts/rate-limits-and-quotas).
+</Note>


### PR DESCRIPTION
This PR includes the following changes:
- Renames the "Rate Limits" section to "Rate Limits and Quotas" and includes information about Global Search API quotas
- Adds a note on each global search endpoint where a quota is applied.


https://github.com/user-attachments/assets/b15b1812-d18c-4daf-99cc-6c6922b2445c

