### PR TITLE
guide(tenant-events): parse the uid

### DIFF
--- a/docs/guides/tenant-events.mdx
+++ b/docs/guides/tenant-events.mdx
@@ -99,6 +99,7 @@ These are end-to-end examples in various programming languages.
 ```python
 import os
 import time
+import urllib.parse
 
 from flareio import FlareApiClient
 
@@ -117,7 +118,7 @@ for resp in api_client.scroll(
     url="/firework/v4/events/tenant/_search",
     json={
         "from": last_from,
-    }
+    },
 ):
     # Rate limiting.
     time.sleep(1)
@@ -136,8 +137,16 @@ for resp in api_client.scroll(
         # Rate limiting.
         time.sleep(1)
 
-        item_uid: str = item["metadata"]["uid"]
-        response = api_client.get(f"/firework/v2/activities/{item_uid}")
+        # This will contain 3 parts: 'index', 'source', and 'id'
+        parsed_uid: list[str] = item["metadata"]["uid"].split("/", maxsplit=2)
+
+        response = api_client.get(
+            "/firework/v2/activities/"
+            + "/".join(
+                urllib.parse.quote_plus(uid_component) for uid_component in parsed_uid
+            )
+        )
+
         full_data = response.json()
         print(f"Here is the full data of the event: {full_data}")
 ```


### PR DESCRIPTION
Until we relase a simpler to use get-events API, here is the safe way to use the current API.