### PR TITLE
Identifier Feed Credentials Documentation Page

### DIFF
--- a/docs/api-reference/spec/firework-v2-openapi.json
+++ b/docs/api-reference/spec/firework-v2-openapi.json
@@ -1781,7 +1781,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -2098,7 +2098,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -2666,7 +2666,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -2983,7 +2983,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -3378,7 +3378,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -3717,7 +3717,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -3993,7 +3993,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -5002,7 +5002,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -5299,7 +5299,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -6432,40 +6432,40 @@
                                 "blog_content",
                                 "profile",
                                 "infected_devices",
-                                "ransomleak",
-                                "forum_post",
-                                "forum_topic",
-                                "chat_message",
+                                "seller",
                                 "bot",
                                 "listing",
-                                "financial_data",
-                                "seller",
-                                "forum_profile",
                                 "blog_post",
+                                "forum_profile",
+                                "ransomleak",
+                                "chat_message",
                                 "stealer_log",
-                                "stack_exchange",
-                                "bucket_object",
-                                "source_code_secrets",
-                                "service",
-                                "source_code_files",
-                                "google",
-                                "bucket",
-                                "paste",
+                                "forum_post",
+                                "financial_data",
+                                "forum_topic",
                                 "social_media",
+                                "google",
+                                "stack_exchange",
+                                "paste",
                                 "bucket",
+                                "source_code_secrets",
                                 "bucket_object",
                                 "source_code_files",
+                                "service",
+                                "bucket",
+                                "bucket_object",
                                 "stack_exchange",
+                                "source_code_files",
                                 "source_code_secrets",
                                 "leak",
                                 "domain",
-                                "forum_topic",
                                 "forum_post",
+                                "forum_topic",
                                 "blog_post",
-                                "seller",
                                 "forum_profile",
-                                "bot",
-                                "stealer_log"
+                                "seller",
+                                "stealer_log",
+                                "bot"
                             ],
                             "example": "illicit_networks",
                             "type": "string"
@@ -7015,12 +7015,6 @@
             },
             "PaginatedCredentials": {
                 "properties": {
-                    "cursors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "items": {
                         "$ref": "#/components/schemas/LeakActivityCredential"
                     },
@@ -7599,12 +7593,6 @@
             },
             "TenantUsers": {
                 "properties": {
-                    "cursors": {
-                        "items": {
-                            "type": "integer"
-                        },
-                        "type": "array"
-                    },
                     "items": {
                         "$ref": "#/components/schemas/TenantUser"
                     },

--- a/docs/api-reference/spec/firework-v2-swagger.json
+++ b/docs/api-reference/spec/firework-v2-swagger.json
@@ -700,40 +700,40 @@
               "blog_content",
               "profile",
               "infected_devices",
-              "ransomleak",
-              "forum_post",
-              "forum_topic",
-              "chat_message",
+              "seller",
               "bot",
               "listing",
-              "financial_data",
-              "seller",
-              "forum_profile",
               "blog_post",
+              "forum_profile",
+              "ransomleak",
+              "chat_message",
               "stealer_log",
-              "stack_exchange",
-              "bucket_object",
-              "source_code_secrets",
-              "service",
-              "source_code_files",
-              "google",
-              "bucket",
-              "paste",
+              "forum_post",
+              "financial_data",
+              "forum_topic",
               "social_media",
+              "google",
+              "stack_exchange",
+              "paste",
               "bucket",
+              "source_code_secrets",
               "bucket_object",
               "source_code_files",
+              "service",
+              "bucket",
+              "bucket_object",
               "stack_exchange",
+              "source_code_files",
               "source_code_secrets",
               "leak",
               "domain",
-              "forum_topic",
               "forum_post",
+              "forum_topic",
               "blog_post",
-              "seller",
               "forum_profile",
-              "bot",
-              "stealer_log"
+              "seller",
+              "stealer_log",
+              "bot"
             ],
             "example": "illicit_networks",
             "type": "string"
@@ -1340,12 +1340,6 @@
     },
     "PaginatedCredentials": {
       "properties": {
-        "cursors": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "items": {
           "$ref": "#/definitions/LeakActivityCredential"
         },
@@ -1970,12 +1964,6 @@
     },
     "TenantUsers": {
       "properties": {
-        "cursors": {
-          "items": {
-            "type": "integer"
-          },
-          "type": "array"
-        },
         "items": {
           "$ref": "#/definitions/TenantUser"
         },
@@ -3739,7 +3727,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -4000,7 +3988,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -4431,7 +4419,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -4692,7 +4680,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -4998,7 +4986,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -5295,7 +5283,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -5526,7 +5514,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -6332,7 +6320,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -6577,7 +6565,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: ransomleak, forum_post, forum_topic, chat_message, bot, listing, financial_data, seller, forum_profile, blog_post, stealer_log\n- open_web: stack_exchange, bucket_object, source_code_secrets, service, source_code_files, google, bucket, paste, social_media\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, bot, listing, blog_post, forum_profile, ransomleak, chat_message, stealer_log, forum_post, financial_data, forum_topic\n- open_web: social_media, google, stack_exchange, paste, bucket, source_code_secrets, bucket_object, source_code_files, service\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",

--- a/docs/api-reference/spec/firework-v3-openapi.json
+++ b/docs/api-reference/spec/firework-v3-openapi.json
@@ -118,7 +118,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedCredentials"
+                                    "$ref": "#/components/schemas/PaginatedCursoredCredentials"
                                 }
                             }
                         },
@@ -469,7 +469,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: forum_topic, listing, ransomleak, stealer_log, financial_data, chat_message, forum_post, seller, blog_post, forum_profile, bot\n- open_web: bucket, social_media, stack_exchange, paste, source_code_files, google, source_code_secrets, service, bucket_object\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, forum_topic, ransomleak, forum_post, chat_message, listing, bot, stealer_log, financial_data, forum_profile, blog_post\n- open_web: stack_exchange, source_code_files, bucket_object, google, service, paste, bucket, social_media, source_code_secrets\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -786,7 +786,7 @@
                         }
                     },
                     {
-                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: forum_topic, listing, ransomleak, stealer_log, financial_data, chat_message, forum_post, seller, blog_post, forum_profile, bot\n- open_web: bucket, social_media, stack_exchange, paste, source_code_files, google, source_code_secrets, service, bucket_object\n- leaks: leak\n- domains: domain\n",
+                        "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, forum_topic, ransomleak, forum_post, chat_message, listing, bot, stealer_log, financial_data, forum_profile, blog_post\n- open_web: stack_exchange, source_code_files, bucket_object, google, service, paste, bucket, social_media, source_code_secrets\n- leaks: leak\n- domains: domain\n",
                         "explode": true,
                         "in": "query",
                         "name": "types",
@@ -2270,7 +2270,10 @@
                     "asset_id": {
                         "type": "integer"
                     },
-                    "asset_types": {
+                    "asset_type": {
+                        "type": "string"
+                    },
+                    "available_asset_types": {
                         "items": {
                             "type": "string"
                         },
@@ -2373,6 +2376,17 @@
             },
             "PaginatedCredentials": {
                 "properties": {
+                    "items": {
+                        "$ref": "#/components/schemas/LeakActivityCredential"
+                    },
+                    "next": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "PaginatedCursoredCredentials": {
+                "properties": {
                     "cursors": {
                         "items": {
                             "type": "string"
@@ -2390,12 +2404,6 @@
             },
             "PaginatedIdentifierGroupsWithCounts": {
                 "properties": {
-                    "cursors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "items": {
                         "$ref": "#/components/schemas/IdentifierGroupWithCounts"
                     },
@@ -2407,12 +2415,6 @@
             },
             "PaginatedIdentifierRelations": {
                 "properties": {
-                    "cursors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "items": {
                         "$ref": "#/components/schemas/Identifier"
                     },
@@ -2424,12 +2426,6 @@
             },
             "PaginatedIdentifiers": {
                 "properties": {
-                    "cursors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "items": {
                         "$ref": "#/components/schemas/Identifier"
                     },

--- a/docs/api-reference/spec/firework-v3-swagger.json
+++ b/docs/api-reference/spec/firework-v3-swagger.json
@@ -599,7 +599,10 @@
         "asset_id": {
           "type": "integer"
         },
-        "asset_types": {
+        "asset_type": {
+          "type": "string"
+        },
+        "available_asset_types": {
           "items": {
             "type": "string"
           },
@@ -702,6 +705,24 @@
     },
     "PaginatedCredentials": {
       "properties": {
+        "items": {
+          "$ref": "#/definitions/LeakActivityCredential"
+        },
+        "next": {
+          "type": "string"
+        },
+        "total_count": {
+          "example": "nullable integer",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "PaginatedCursoredCredentials": {
+      "properties": {
         "cursors": {
           "items": {
             "type": "string"
@@ -726,12 +747,6 @@
     },
     "PaginatedIdentifierGroupsWithCounts": {
       "properties": {
-        "cursors": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "items": {
           "$ref": "#/definitions/IdentifierGroupWithCounts"
         },
@@ -750,12 +765,6 @@
     },
     "PaginatedIdentifierRelations": {
       "properties": {
-        "cursors": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "items": {
           "$ref": "#/definitions/Identifier"
         },
@@ -774,12 +783,6 @@
     },
     "PaginatedIdentifiers": {
       "properties": {
-        "cursors": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "items": {
           "$ref": "#/definitions/Identifier"
         },
@@ -932,7 +935,7 @@
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/PaginatedCredentials"
+              "$ref": "#/definitions/PaginatedCursoredCredentials"
             }
           }
         },
@@ -1241,7 +1244,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: forum_topic, listing, ransomleak, stealer_log, financial_data, chat_message, forum_post, seller, blog_post, forum_profile, bot\n- open_web: bucket, social_media, stack_exchange, paste, source_code_files, google, source_code_secrets, service, bucket_object\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, forum_topic, ransomleak, forum_post, chat_message, listing, bot, stealer_log, financial_data, forum_profile, blog_post\n- open_web: stack_exchange, source_code_files, bucket_object, google, service, paste, bucket, social_media, source_code_secrets\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",
@@ -1502,7 +1505,7 @@
           },
           {
             "collectionFormat": "multi",
-            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: forum_topic, listing, ransomleak, stealer_log, financial_data, chat_message, forum_post, seller, blog_post, forum_profile, bot\n- open_web: bucket, social_media, stack_exchange, paste, source_code_files, google, source_code_secrets, service, bucket_object\n- leaks: leak\n- domains: domain\n",
+            "description": "\nType of activities to search through.\n\n*Expected values* : attachment, listing, ransomleak, forum_post, forum_topic, forum_profile, blog_post, seller, paste, leak, chat_message, chat_message/telegram, domain, bot, stealer_log, infected_devices, driller, driller_forum_topic, driller_forum_post, driller_profile, cc, ccbin, financial_data, leaked_data, leaked_file, document, account, actor, forum_content, blog_content, profile, illicit_networks, open_web, domains, leaks, social_media_account, social_media, source_code, source_code_secrets, source_code_files, stack_exchange, google, service, driller_host, buckets, bucket, bucket_object, whois, experimental\n\n*Some search types contain others*\n- illicit_networks: seller, forum_topic, ransomleak, forum_post, chat_message, listing, bot, stealer_log, financial_data, forum_profile, blog_post\n- open_web: stack_exchange, source_code_files, bucket_object, google, service, paste, bucket, social_media, source_code_secrets\n- leaks: leak\n- domains: domain\n",
             "enum": [
               "attachment",
               "listing",

--- a/docs/api-reference/v3/endpoints/identifiers/get-identifiers-feedcredentials.mdx
+++ b/docs/api-reference/v3/endpoints/identifiers/get-identifiers-feedcredentials.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: firework-v3-openapi get /identifiers/{identifier_id}/feed/credentials
+title: List Identifier Credentials
 ---

--- a/docs/api-reference/v3/endpoints/identifiers/post-identifiers-feedcredentials.mdx
+++ b/docs/api-reference/v3/endpoints/identifiers/post-identifiers-feedcredentials.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: firework-v3-openapi post /identifiers/{identifier_id}/feed/credentials
+openapi: post /identifiers/{identifier_id}/feed/credentials
 ---

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -178,6 +178,7 @@
           "pages": [
             "api-reference/v4/endpoints/current-tenant-feed",
             "api-reference/v2/endpoints/me/get-mefeedcredentials",
+            "api-reference/v3/endpoints/identifiers/get-identifiers-feedcredentials",
             "api-reference/v4/endpoints/identifier-feed",
             "api-reference/v4/endpoints/identifier-group-feed"
           ]
@@ -296,6 +297,7 @@
           "group": "Event Feeds",
           "pages": [
             "api-reference/v2/endpoints/me/get-mefeed",
+            "api-reference/v3/endpoints/identifiers/get-identifiers-feedcredentials",
             "api-reference/v2/endpoints/identifiers/get-assets-feed",
             "api-reference/v2/endpoints/identifiers/get-assetsgroups-feed"
           ]


### PR DESCRIPTION
This PR is to add a new page to the documentation to fetch Leaked Credentials from an Identifier Feed.

![Screenshot 2025-01-27 at 11 27 07 AM](https://github.com/user-attachments/assets/9fb73494-940b-4d87-bb8c-db83dc6770e6)
