### PR TITLE
examples: sleep 0.25s

### DIFF
--- a/docs/concepts/paging.mdx
+++ b/docs/concepts/paging.mdx
@@ -89,8 +89,8 @@ for resp in api_client.scroll(
         "from": None,
     },
 ):
-    # Rate limiting.
-    time.sleep(1)
+    # Rate limiting (default).
+    time.sleep(0.25)
 
     # Get results from the response
     resp_data = resp.json()
@@ -124,8 +124,8 @@ from_: str | None = None
 fetched_pages: int = 0
 
 while True:
-    # Rate limiting.
-    time.sleep(1)
+    # Rate limiting (default).
+    time.sleep(0.25)
 
     params: dict = {}
     if from_:

--- a/docs/guides/cookie-monitoring.mdx
+++ b/docs/guides/cookie-monitoring.mdx
@@ -89,8 +89,8 @@ for resp in api_client.scroll(
         ).isoformat(),
     },
 ):
-    # Rate limiting.
-    time.sleep(0.2)
+    # Rate limiting (default).
+    time.sleep(0.25)
 
     resp_data: dict = resp.json()
 

--- a/docs/guides/credentials-export-domain.mdx
+++ b/docs/guides/credentials-export-domain.mdx
@@ -86,7 +86,7 @@ for resp in api_client.scroll(
         )
 
     # Rate limiting.
-    time.sleep(1)
+    time.sleep(0.25)
 ```
 </Accordion>
 

--- a/docs/guides/global-search.mdx
+++ b/docs/guides/global-search.mdx
@@ -80,7 +80,7 @@ for resp in api_client.scroll(
         },
     },
 ):
-    # Rate limiting.
+    # Rate limiting (search).
     time.sleep(1)
 
     resp_data: dict = resp.json()
@@ -94,8 +94,8 @@ for resp in api_client.scroll(
 
     # (Optional): Get the full data
     for item in items:
-        # Rate limiting.
-        time.sleep(1)
+        # Rate limiting (default).
+        time.sleep(0.25)
 
         event_response = api_client.get(
             url="/firework/v2/activities/",

--- a/docs/guides/tenant-events.mdx
+++ b/docs/guides/tenant-events.mdx
@@ -117,7 +117,7 @@ for resp in api_client.scroll(
         "from": last_from,
     },
 ):
-    # Rate limiting.
+    # Rate limiting (search).
     time.sleep(1)
 
     resp_data: dict = resp.json()
@@ -131,8 +131,8 @@ for resp in api_client.scroll(
 
     # (Optional): Get the full data
     for item in resp_data["items"]:
-        # Rate limiting.
-        time.sleep(1)
+        # Rate limiting (default).
+        time.sleep(0.25)
 
         event_response = api_client.get(
             url="/firework/v2/activities/",

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -86,8 +86,8 @@ for resp in api_client.scroll(
         "from": None,
     },
 ):
-    # Rate limiting.
-    time.sleep(1)
+    # Rate limiting (default).
+    time.sleep(0.25)
 
     # Get results from the response
     resp_data = resp.json()


### PR DESCRIPTION
Our default ratelimit is now 4 per second, so let's update our examples to reflect that.