### PR TITLE
Fix cursor examples in python SDK snippets

### DIFF
--- a/docs/concepts/paging.mdx
+++ b/docs/concepts/paging.mdx
@@ -86,7 +86,7 @@ for resp in api_client.scroll(
     method="GET",
     url="/leaksdb/v2/sources",
     params={
-        "from": None,
+        "from": last_from,
     },
 ):
     # Rate limiting (default).

--- a/docs/guides/global-search.mdx
+++ b/docs/guides/global-search.mdx
@@ -66,7 +66,7 @@ for resp in api_client.scroll(
     json={
         "size": 10,
         "order": "asc",
-        "from": None,
+        "from": last_from,
         "filters": {
             "type": ["chat_message"],
             "estimated_created_at": {"gte": from_timestamp},

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -83,7 +83,7 @@ for resp in api_client.scroll(
     method="GET",
     url="/leaksdb/v2/sources",
     params={
-        "from": None,
+        "from": last_from,
     },
 ):
     # Rate limiting (default).
@@ -106,7 +106,6 @@ print("The last value for 'next' was", last_from)
 
 The `FlareApiClient` can be initialized with a custom `requests.Session`. This allows, for example,
 to inject custom retry configuration.
-
 
 ```python Custom Session
 import requests


### PR DESCRIPTION
Before
<img width="273" alt="image" src="https://github.com/user-attachments/assets/3eface36-6ca9-4352-b1df-a2b711ff2228" />

After
<img width="263" alt="image" src="https://github.com/user-attachments/assets/8b36f088-65fd-49d2-aec6-0f89bd697769" />
