### PR TITLE
leaksdb search: remove redundant astp warning

### DIFF
--- a/docs/api-reference/leaksdb/endpoints/post-credentials-search.mdx
+++ b/docs/api-reference/leaksdb/endpoints/post-credentials-search.mdx
@@ -97,7 +97,6 @@ See the guide for using this endpoint:
     </Tab>
 
     <Tab title="Auth Domain Query" >
-    <GatedAccessFeatureAstp />
     This query will match the domain of the service that this credential might have been used to log in to.
     ```json
     {


### PR DESCRIPTION
I noticed this. This is now redundant since we already have a warning on the top of the page.