### PR TITLE
Fix typo in errors concept doc

### DIFF
--- a/docs/concepts/errors.mdx
+++ b/docs/concepts/errors.mdx
@@ -23,7 +23,7 @@ Flare APIs return a common error format for HTTP 4XX error codes.
 <ResponseField name="code" type="string">
   The code of the errors.
   
-  These are stable and could be used programatically to detect and handle the error type.
+  These are stable and could be used programmatically to detect and handle the error type.
 </ResponseField>
 
 <ResponseField name="message" type="string">


### PR DESCRIPTION
## Summary
- fix `programatically` typo in docs

## Testing
- `grep -n program docs/concepts/errors.mdx`

------
https://chatgpt.com/codex/tasks/task_b_6841dda6449c8323ab232bf2550bf2f1