### PR TITLE
ioc: fix rendering issue transforming double hyphen into en dash

### DIFF
--- a/docs/guides/ioc-feeds.mdx
+++ b/docs/guides/ioc-feeds.mdx
@@ -14,10 +14,10 @@ at `https://api.flare.io/taxii2/`.
 
 | Feed | TAXII 2 ID |
 | ---- | ---------- |
-| Full Feed (with context) | d6092c37-d8d7-45c3-8aff-c4dc26030608 |
-| IPV4 Only | feed--689f0191-3b4d-47c8-9313-85820aae7c27 |
-| Domains Only | feed--a2e7ea2d-ec01-4550-91e5-1316282d01a0 |
-| URLs Only | feed--af0848cc-ae01-4937-93fe-5d9bf69ba3d2 |
+| Full Feed (with context) | `d6092c37-d8d7-45c3-8aff-c4dc26030608` |
+| IPV4 Only | `feed--689f0191-3b4d-47c8-9313-85820aae7c27` |
+| Domains Only | `feed--a2e7ea2d-ec01-4550-91e5-1316282d01a0` |
+| URLs Only | `feed--af0848cc-ae01-4937-93fe-5d9bf69ba3d2` |
 
 Feed URLs can be constructed using:
 - Format: `https://api.flare.io/taxii2/collections/<TAXII 2 ID >/`


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="509" height="231" alt="image" src="https://github.com/user-attachments/assets/af25218e-4abd-4ffc-84c1-70bb31fc57be" /> | <img width="507" height="239" alt="image" src="https://github.com/user-attachments/assets/5a13366c-0b51-45ae-a12a-97ae813f15fb" /> | 