### PR TITLE
document `include` param in firework & astp cred search with examples

### DIFF
--- a/docs/api-reference/spec/firework-v4-openapi.json
+++ b/docs/api-reference/spec/firework-v4-openapi.json
@@ -15299,6 +15299,13 @@
                             }
                         ],
                         "title": "Event Uid"
+                    },
+                    "auth_domains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Auth Domains"
                     }
                 },
                 "type": "object",
@@ -21029,7 +21036,8 @@
             "IncludeOptions": {
                 "type": "string",
                 "enum": [
-                    "known_password_id"
+                    "known_password_id",
+                    "auth_domains"
                 ],
                 "title": "IncludeOptions"
             },

--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -13,6 +13,10 @@ Release notes for the Flare Platform can be found on the [product documentation 
 </Note>
 
 <Update label="2026-03" description="API - March 2026">
+  Added new value for the `include` parameter in the [Global Search Credentials Endpoint <Icon icon="code" size={16} />](/api-reference/v4/endpoints/credentials-global-search).
+
+  Added documentation for the `include` parameter in the [ASTP Search Credentials Endpoint <Icon icon="code" size={16} />](/api-reference/astp/endpoints/post-credentials-search).
+
   Replaced the `leak` event type for individual `leaked_credential` events. See [Leaked Credentials <Icon icon="book" size={16} />](/event-types/leaked-credential)
 </Update>
 

--- a/docs/snippets/credentials/astp-and-global-search-common.mdx
+++ b/docs/snippets/credentials/astp-and-global-search-common.mdx
@@ -4,6 +4,7 @@
 {
     "items": [
         {
+            "auth_domains": ["login.live.com"],
             "domain": "scatterholt.com",
             "hash": "B@dPassw0rd",
             "hash_type": null,
@@ -23,6 +24,7 @@
             "source_id": "combolists"
         },
         {
+            "auth_domains": ["www.facebook.com", "discord.com"],
             "domain": "scatterholt.com",
             "hash": "1qaz2wsx",
             "hash_type": "unknown",
@@ -61,6 +63,12 @@ This endpoint supports the
 
 <ParamField body="from" type="string">
   The `next` value from the last response.
+</ParamField>
+
+<ParamField body="include" type="string[]">
+  Additional fields to return. Available options:
+    - `known_password_id`: ID of the credential's password.
+    - `auth_domains`: for each credential, return up to 10 domains where this credential was used.
 </ParamField>
 
 <ParamField body="order" type="string" default="desc">


### PR DESCRIPTION
Added documentation for a new enum value (auth_domains) for the include parameter in credential search. Also added documentation for the include parameter to the ASTP version of the endpoint. Updated examples with populated `auth_domains` fields and updated changelog for March 2026.

Screenshots from make run:

ASTP docs:
<img width="1917" height="1038" alt="image" src="https://github.com/user-attachments/assets/5b5507e5-c1e3-44e1-a249-8840fa97beb8" />

Firework docs:
<img width="1920" height="1037" alt="image" src="https://github.com/user-attachments/assets/50923aa2-3e9b-4ca1-86d8-4953a3633ae3" />

Changelog docs:
<img width="1920" height="1039" alt="image" src="https://github.com/user-attachments/assets/837acade-7558-48c9-abdc-0892898baa8f" />
