### PR TITLE
Remove warning banner for the `imported_at` param in credential search endpoints.

### DIFF
--- a/docs/api-reference/spec/firework-v4-openapi.json
+++ b/docs/api-reference/spec/firework-v4-openapi.json
@@ -15299,6 +15299,13 @@
                             }
                         ],
                         "title": "Event Uid"
+                    },
+                    "auth_domains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Auth Domains"
                     }
                 },
                 "type": "object",
@@ -21029,7 +21036,8 @@
             "IncludeOptions": {
                 "type": "string",
                 "enum": [
-                    "known_password_id"
+                    "known_password_id",
+                    "auth_domains"
                 ],
                 "title": "IncludeOptions"
             },

--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -13,6 +13,10 @@ Release notes for the Flare Platform can be found on the [product documentation 
 </Note>
 
 <Update label="2026-03" description="API - March 2026">
+  Added new value for the `include` parameter in the [Global Search Credentials Endpoint <Icon icon="code" size={16} />](/api-reference/v4/endpoints/credentials-global-search).
+
+  Added documentation for the `include` parameter in the [ASTP Search Credentials Endpoint <Icon icon="code" size={16} />](/api-reference/astp/endpoints/post-credentials-search).
+
   Replaced the `leak` event type for individual `leaked_credential` events. See [Leaked Credentials <Icon icon="book" size={16} />](/event-types/leaked-credential)
 </Update>
 

--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -12,6 +12,11 @@ This page lists changes to Flare's API.
 Release notes for the Flare Platform can be found on the [product documentation website](https://docs.flare.io/releases).
 </Note>
 
+<Update label="2026-05" description="API - May 2026">
+  The `imported_at` filter now works for all query types in the [Global Search Credentials Endpoint <Icon icon="code" size={16} />](/api-reference/v4/endpoints/credentials-global-search)
+  and the [ASTP Search Credentials Endpoint <Icon icon="code" size={16} />](/api-reference/astp/endpoints/post-credentials-search).
+</Update>
+
 <Update label="2026-04" description="API - April 2026">
   Added new endpoints to manage [Matching Policies <Icon icon="code" size={16} />](/api-reference/v4/endpoints/list-matching-policies).
 

--- a/docs/snippets/credentials/astp-and-global-search-common.mdx
+++ b/docs/snippets/credentials/astp-and-global-search-common.mdx
@@ -4,6 +4,7 @@
 {
     "items": [
         {
+            "auth_domains": ["login.live.com"],
             "domain": "scatterholt.com",
             "hash": "B@dPassw0rd",
             "hash_type": null,
@@ -23,6 +24,7 @@
             "source_id": "combolists"
         },
         {
+            "auth_domains": ["www.facebook.com", "discord.com"],
             "domain": "scatterholt.com",
             "hash": "1qaz2wsx",
             "hash_type": "unknown",
@@ -61,6 +63,12 @@ This endpoint supports the
 
 <ParamField body="from" type="string">
   The `next` value from the last response.
+</ParamField>
+
+<ParamField body="include" type="string[]">
+  Additional fields to return. Available options:
+    - `known_password_id`: ID of the credential's password.
+    - `auth_domains`: for each credential, return up to 10 domains where this credential was used.
 </ParamField>
 
 <ParamField body="order" type="string" default="desc">

--- a/docs/snippets/credentials/astp-and-global-search-common.mdx
+++ b/docs/snippets/credentials/astp-and-global-search-common.mdx
@@ -135,10 +135,6 @@ This endpoint supports the
 <ParamField body="filters" type="object">
   <Expandable defaultOpen>
     <ParamField body="imported_at" type="object">
-      <Note>
-        This filter only works for Auth Domain Queries. It will be ignored if used with other query types.
-      </Note>
-
       <Expandable>
         <ParamField
           body="gte"


### PR DESCRIPTION
The `imported_at` param works for all query types now.

**Screenshots before:**
<img width="1917" height="980" alt="image" src="https://github.com/user-attachments/assets/5695479e-f4c9-4d51-ac27-ff67c673e687" />

<img width="1900" height="1014" alt="image" src="https://github.com/user-attachments/assets/db2c39c6-44f0-42ef-83b4-b31f762b326a" />



**Screenshots after:**
<img width="1913" height="987" alt="image" src="https://github.com/user-attachments/assets/bc40caba-646f-4c56-8f47-3e602ee65348" />

<img width="1914" height="1030" alt="image" src="https://github.com/user-attachments/assets/410e5c42-fb3a-474b-b149-c92375804cbf" />


**Changelog:**
<img width="1874" height="970" alt="image" src="https://github.com/user-attachments/assets/53410ba9-466a-450b-8a8e-2a3f4004ca8e" />