### PR TITLE
Add new identifier endpoints to the sidebar and deprecate old endpoints

### DIFF
--- a/docs/api-reference/v2/endpoints/identifiers/delete-fireworkv2assets.mdx
+++ b/docs/api-reference/v2/endpoints/identifiers/delete-fireworkv2assets.mdx
@@ -2,3 +2,8 @@
 openapi: firework-v2-openapi delete /firework/v2/assets/{asset_id}
 title: Delete Identifier
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint should be replaced by
+[/firework/v4/identifiers/\{identifier_id\} <Icon icon="code" size={16} />](/api-reference/v4/endpoints/delete-identifier)
+</Warning>

--- a/docs/api-reference/v2/endpoints/identifiers/post-fireworkv2assets-toggle.mdx
+++ b/docs/api-reference/v2/endpoints/identifiers/post-fireworkv2assets-toggle.mdx
@@ -2,3 +2,8 @@
 openapi: firework-v2-openapi post /firework/v2/assets/{asset_id}/toggle
 title: Enable/Disable Identifier
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint should be replaced by
+[/firework/v4/identifiers/\{identifier_id\} <Icon icon="code" size={16} />](/api-reference/v4/endpoints/update-identifier)
+</Warning>

--- a/docs/api-reference/v2/endpoints/identifiers/post-fireworkv2assets.mdx
+++ b/docs/api-reference/v2/endpoints/identifiers/post-fireworkv2assets.mdx
@@ -2,3 +2,8 @@
 openapi: firework-v2-openapi post /firework/v2/assets/
 title: Create Identifier
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint should be replaced by
+[/firework/v4/identifiers/ <Icon icon="code" size={16} />](/api-reference/v4/endpoints/create-identifier)
+</Warning>

--- a/docs/api-reference/v2/endpoints/identifiers/put-fireworkv2assets.mdx
+++ b/docs/api-reference/v2/endpoints/identifiers/put-fireworkv2assets.mdx
@@ -2,3 +2,8 @@
 openapi: firework-v2-openapi put /firework/v2/assets/{asset_id}
 title: Update Identifier
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint should be replaced by
+[/firework/v4/identifiers/\{identifier_id\} <Icon icon="code" size={16} />](/api-reference/v4/endpoints/update-identifier)
+</Warning>

--- a/docs/api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers-1.mdx
+++ b/docs/api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers-1.mdx
@@ -2,3 +2,8 @@
 openapi: firework-v3-openapi get /firework/v3/identifiers/{identifier_id}
 title: Retrieve Identifier
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint should be replaced by
+[/firework/v4/identifiers/\{identifier_id\} <Icon icon="code" size={16} />](/api-reference/v4/endpoints/retrieve-identifier)
+</Warning>

--- a/docs/api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers.mdx
+++ b/docs/api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers.mdx
@@ -2,3 +2,8 @@
 openapi: firework-v3-openapi get /firework/v3/identifiers/
 title: List Identifiers
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint should be replaced by
+[/firework/v4/identifiers/ <Icon icon="code" size={16} />](/api-reference/v4/endpoints/list-identifiers)
+</Warning>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -134,12 +134,11 @@
               {
                 "group": "Identifiers",
                 "pages": [
-                  "api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers",
-                  "api-reference/v2/endpoints/identifiers/post-fireworkv2assets",
-                  "api-reference/v2/endpoints/identifiers/put-fireworkv2assets",
-                  "api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers-1",
-                  "api-reference/v2/endpoints/identifiers/delete-fireworkv2assets",
-                  "api-reference/v2/endpoints/identifiers/post-fireworkv2assets-toggle"
+                  "api-reference/v4/endpoints/list-identifiers",
+                  "api-reference/v4/endpoints/create-identifier",
+                  "api-reference/v4/endpoints/update-identifier",
+                  "api-reference/v4/endpoints/retrieve-identifier",
+                  "api-reference/v4/endpoints/delete-identifier"
                 ]
               },
               {
@@ -276,6 +275,17 @@
                   "api-reference/v2/endpoints/me/get-fireworkv2mefeed",
                   "api-reference/v2/endpoints/identifiers/get-fireworkv2assets-feed",
                   "api-reference/v2/endpoints/identifiers/get-fireworkv2assetsgroups-feed"
+                ]
+              },
+              {
+                "group": "Identifiers",
+                "pages": [
+                  "api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers",
+                  "api-reference/v2/endpoints/identifiers/post-fireworkv2assets",
+                  "api-reference/v2/endpoints/identifiers/put-fireworkv2assets",
+                  "api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers-1",
+                  "api-reference/v2/endpoints/identifiers/delete-fireworkv2assets",
+                  "api-reference/v2/endpoints/identifiers/post-fireworkv2assets-toggle"
                 ]
               }
             ]


### PR DESCRIPTION
The five new Identifier endpoints (LIST, CREATE, UPDATE, RETRIEVE, and DELETE) have been added to the Identifiers section of the sidebar, replacing the deprecated endpoints.

<img width="264" height="329" alt="Screenshot 2026-06-04 at 4 59 18 PM" src="https://github.com/user-attachments/assets/83c8a10f-3681-4c3f-b651-ef336f0b6a01" />

The previous endpoints are moved to the deprecated section with Warnings that redirect to the new endpoints :

<img width="1887" height="836" alt="Screenshot 2026-06-04 at 4 58 40 PM" src="https://github.com/user-attachments/assets/bcaac7f4-55c2-4550-84c4-c9d6d4f9af53" />

<img width="1890" height="811" alt="Screenshot 2026-06-04 at 4 58 46 PM" src="https://github.com/user-attachments/assets/b6385cb5-add7-4cf1-8a5f-9153c728fbb2" />

<img width="1889" height="830" alt="Screenshot 2026-06-04 at 4 58 51 PM" src="https://github.com/user-attachments/assets/7b2f4e92-c779-44ea-beea-b14c4cf948cd" />

<img width="1881" height="819" alt="Screenshot 2026-06-04 at 4 58 59 PM" src="https://github.com/user-attachments/assets/1f84155f-f8c2-4569-95b1-855e8a881651" />

<img width="1886" height="828" alt="Screenshot 2026-06-04 at 4 59 06 PM" src="https://github.com/user-attachments/assets/82ff8d4d-1c96-4196-8700-9cdb90d478e5" />

<img width="1879" height="818" alt="Screenshot 2026-06-04 at 4 59 11 PM" src="https://github.com/user-attachments/assets/85e95dbf-3419-4af8-a5a8-e4307e2380fb" />