### PR TITLE
Codeowners: Add Integrations Team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aviau @xvaier
+* @aviau @xvaier @ireydiak @ihassanein @aaparent


### PR DESCRIPTION
This adds myself, Jean-Charles and Antoine to the codeowners. This would allow us to approve changes to the public API doc to be merged.