### PR TITLE
document ASTP List URLs by Credential Hash endpoint

### DIFF
--- a/docs/api-reference/astp/endpoints/post-urls-by-credential-hash.mdx
+++ b/docs/api-reference/astp/endpoints/post-urls-by-credential-hash.mdx
@@ -1,0 +1,60 @@
+---
+title: "List URLs by Credential Hash"
+api: "POST https://api.flare.io/astp/urls/by_credential_hash"
+authMethod: "bearer"
+---
+
+import GatedAccessFeatureAstp from '/snippets/gated-access-feature-astp.mdx';
+
+<GatedAccessFeatureAstp />
+
+Returns the URLs where a leaked credential was seen being used, for a single credential hash.
+
+Credential hashes are returned in the `credential_hash` field of each credential from the
+[Search Credentials <Icon icon="code" size={16} />](/api-reference/astp/endpoints/post-credentials-search)
+endpoint.
+
+Each result contains the full `url` (including scheme and path), its host (`domain`), and the
+`credential_hash` it belongs to.
+
+<ResponseExample>
+
+```json Response Example
+{
+    "items": [
+        {
+            "url": "https://login.example.com/signin",
+            "domain": "login.example.com",
+            "credential_hash": "43804850e72d054f3648660557330630"
+        },
+        {
+            "url": "https://mail.example.com/",
+            "domain": "mail.example.com",
+            "credential_hash": "43804850e72d054f3648660557330630"
+        }
+    ],
+    "next": "WyJtYWlsLmV4YW1wbGUuY29tIl0"
+}
+```
+
+</ResponseExample>
+
+## Paging
+
+This endpoint supports the
+[Flare standard paging pattern <Icon icon="book" size={16} />](/concepts/paging).
+Use the `next` value from the response as the `from` value in the next request to fetch additional URLs.
+
+## Body Parameters
+
+<ParamField body="credential_hash" type="string" required>
+  The credential hash to look up URLs for, as returned in the `credential_hash` field of a credential.
+</ParamField>
+
+<ParamField body="size" type="number" default="100">
+  Maximum number of URLs to return (maximum 5000).
+</ParamField>
+
+<ParamField body="from" type="string">
+  The `next` value from the last response.
+</ParamField>

--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -14,6 +14,8 @@ Release notes for the Flare Platform can be found on the [product documentation 
 
 <Update label="2026-07" description="API - July 2026">
   Added the `urls` value to the `include` parameter in the [ASTP Search Credentials Endpoint <Icon icon="code" size={16} />](/api-reference/astp/endpoints/post-credentials-search).
+
+  Added the [ASTP List URLs by Credential Hash Endpoint <Icon icon="code" size={16} />](/api-reference/astp/endpoints/post-urls-by-credential-hash) to list the URLs where a leaked credential was seen.
 </Update>
 
 <Update label="2026-05" description="API - May 2026">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -115,6 +115,7 @@
                 "group": "Credentials",
                 "pages": [
                   "api-reference/astp/endpoints/post-credentials-search",
+                  "api-reference/astp/endpoints/post-urls-by-credential-hash",
                   "api-reference/astp/endpoints/post-by-accounts",
                   "api-reference/astp/endpoints/get-sources",
                   "api-reference/astp/endpoints/get-source"


### PR DESCRIPTION
Adds the reference page for POST /astp/urls/by_credential_hash, which lists the URLs where a leaked credential (by credential hash) was seen. Wires it into the ASTP > Credentials nav and the changelog.

Preview:
<img width="2509" height="1264" alt="image" src="https://github.com/user-attachments/assets/eb43d6ca-33ef-4079-9c34-5588845fd68b" />
