### PR TITLE
C33 - Events - Add docs for new V2 Events endpoints

### DIFF
--- a/docs/api-reference/spec/firework-v4-openapi.json
+++ b/docs/api-reference/spec/firework-v4-openapi.json
@@ -418,10 +418,19 @@
                                                     "$ref": "#/components/schemas/ForumPostEvent"
                                                 },
                                                 {
+                                                    "$ref": "#/components/schemas/InvalidCredentialEvent"
+                                                },
+                                                {
+                                                    "$ref": "#/components/schemas/LeakedCredentialEvent"
+                                                },
+                                                {
                                                     "$ref": "#/components/schemas/ListingEvent"
                                                 },
                                                 {
                                                     "$ref": "#/components/schemas/LookalikeDomainEvent"
+                                                },
+                                                {
+                                                    "$ref": "#/components/schemas/MitigatedCredentialEvent"
                                                 },
                                                 {
                                                     "$ref": "#/components/schemas/PasteEvent"
@@ -434,6 +443,9 @@
                                                 },
                                                 {
                                                     "$ref": "#/components/schemas/pyro__findings__stealerlogs__datamodels__StealerLogEvent"
+                                                },
+                                                {
+                                                    "$ref": "#/components/schemas/ValidCredentialEvent"
                                                 }
                                             ],
                                             "discriminator": {
@@ -444,12 +456,16 @@
                                                     "chat_message": "#/components/schemas/ChatMessageEvent",
                                                     "cc": "#/components/schemas/FinancialEvent",
                                                     "forum_post": "#/components/schemas/ForumPostEvent",
+                                                    "invalid_credential": "#/components/schemas/InvalidCredentialEvent",
+                                                    "leaked_credential": "#/components/schemas/LeakedCredentialEvent",
                                                     "listing": "#/components/schemas/ListingEvent",
                                                     "lookalike": "#/components/schemas/LookalikeDomainEvent",
+                                                    "mitigated_credential": "#/components/schemas/MitigatedCredentialEvent",
                                                     "paste": "#/components/schemas/PasteEvent",
                                                     "ransomleak": "#/components/schemas/RansomLeakEvent",
                                                     "social_media_account": "#/components/schemas/SocialMediaEvent",
-                                                    "stealer_log": "#/components/schemas/pyro__findings__stealerlogs__datamodels__StealerLogEvent"
+                                                    "stealer_log": "#/components/schemas/pyro__findings__stealerlogs__datamodels__StealerLogEvent",
+                                                    "valid_credential": "#/components/schemas/ValidCredentialEvent"
                                                 }
                                             }
                                         },
@@ -2608,6 +2624,7 @@
                     "driller_profile",
                     "driller_source_code",
                     "entity_classification",
+                    "entity_summarization",
                     "event",
                     "experimental",
                     "forum_category",
@@ -4417,6 +4434,32 @@
                     "credential_hash"
                 ],
                 "title": "CredentialActionTarget"
+            },
+            "CredentialEventData": {
+                "properties": {
+                    "identity_name": {
+                        "type": "string",
+                        "title": "Identity Name",
+                        "description": "The email or username associated with the credential."
+                    },
+                    "credential_hash": {
+                        "type": "string",
+                        "title": "Credential Hash",
+                        "description": "A hash uniquely identifying the credential."
+                    },
+                    "tenant_integration_id": {
+                        "type": "string",
+                        "title": "Tenant Integration Id",
+                        "description": "The UUID of the tenant's IdP integration that validated the credential."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "identity_name",
+                    "credential_hash",
+                    "tenant_integration_id"
+                ],
+                "title": "CredentialEventData"
             },
             "CredentialsData": {
                 "properties": {
@@ -7192,6 +7235,28 @@
                 ],
                 "title": "IntelType"
             },
+            "InvalidCredentialEvent": {
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "invalid_credential",
+                        "title": "Event Type",
+                        "default": "invalid_credential"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/EventMetadata"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/CredentialEventData"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "metadata",
+                    "data"
+                ],
+                "title": "Invalid Credential"
+            },
             "IpQuery": {
                 "properties": {
                     "type": {
@@ -7273,6 +7338,80 @@
                     "fr"
                 ],
                 "title": "Language"
+            },
+            "LeakedCredentialEvent": {
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "leaked_credential",
+                        "title": "Event Type",
+                        "default": "leaked_credential"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/EventMetadata"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/LeakedCredentialEventData"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "metadata",
+                    "data"
+                ],
+                "title": "Leaked Credential"
+            },
+            "LeakedCredentialEventData": {
+                "properties": {
+                    "identity_name": {
+                        "type": "string",
+                        "title": "Identity Name",
+                        "description": "The email or username associated with the leaked credential."
+                    },
+                    "imported_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Imported At",
+                        "description": "When the credential was imported into Flare."
+                    },
+                    "password": {
+                        "type": "string",
+                        "title": "Password",
+                        "description": "The leaked password, or its hash if not available in cleartext."
+                    },
+                    "source": {
+                        "$ref": "#/components/schemas/LeakedCredentialEventSource",
+                        "description": "The source the credential was leaked from."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "identity_name",
+                    "imported_at",
+                    "password",
+                    "source"
+                ],
+                "title": "LeakedCredentialEventData"
+            },
+            "LeakedCredentialEventSource": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "title": "Id",
+                        "description": "The identifier of the leak source category."
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "The name of the leak source category."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "title": "LeakedCredentialEventSource"
             },
             "LeakedCredentialsBulkActionType": {
                 "type": "string",
@@ -7700,6 +7839,60 @@
                     "ASTP_DOMAIN"
                 ],
                 "title": "MatchingPolicyType"
+            },
+            "MitigatedCredentialEvent": {
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "mitigated_credential",
+                        "title": "Event Type",
+                        "default": "mitigated_credential"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/EventMetadata"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/MitigatedCredentialEventData"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "metadata",
+                    "data"
+                ],
+                "title": "Mitigated Credential"
+            },
+            "MitigatedCredentialEventData": {
+                "properties": {
+                    "identity_name": {
+                        "type": "string",
+                        "title": "Identity Name",
+                        "description": "The email or username associated with the credential."
+                    },
+                    "credential_hash": {
+                        "type": "string",
+                        "title": "Credential Hash",
+                        "description": "A hash uniquely identifying the credential."
+                    },
+                    "tenant_integration_id": {
+                        "type": "string",
+                        "title": "Tenant Integration Id",
+                        "description": "The UUID of the tenant's IdP integration that validated the credential."
+                    },
+                    "mitigation_action": {
+                        "type": "string",
+                        "title": "Mitigation Action",
+                        "description": "The action the tenant's IdP integration took to mitigate the credential"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "identity_name",
+                    "credential_hash",
+                    "tenant_integration_id",
+                    "mitigation_action"
+                ],
+                "title": "MitigatedCredentialEventData"
             },
             "NameData": {
                 "properties": {
@@ -9892,6 +10085,34 @@
                 ],
                 "title": "SubdomainTag"
             },
+            "Tag": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "repository_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Repository Name"
+                    }
+                },
+                "type": "object",
+                "title": "Tag"
+            },
             "TenantMetadataResponse": {
                 "properties": {
                     "uid": {
@@ -10133,6 +10354,28 @@
                     "username"
                 ],
                 "title": "UsernameQuery"
+            },
+            "ValidCredentialEvent": {
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "valid_credential",
+                        "title": "Event Type",
+                        "default": "valid_credential"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/EventMetadata"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/CredentialEventData"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "metadata",
+                    "data"
+                ],
+                "title": "Valid Credential"
             },
             "ValidationError": {
                 "properties": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -328,11 +328,15 @@
               "event-types-v2/chat-message",
               "event-types-v2/domain",
               "event-types-v2/forum-post",
+              "event-types-v2/invalid-credential",
+              "event-types-v2/leaked-credential",
               "event-types-v2/listing",
+              "event-types-v2/mitigated-credential",
               "event-types-v2/paste",
               "event-types-v2/ransom-leak",
               "event-types-v2/social-media-account",
-              "event-types-v2/stealer-log"
+              "event-types-v2/stealer-log",
+              "event-types-v2/valid-credential"
             ]
           }
         ]

--- a/docs/event-types-v2/invalid-credential.mdx
+++ b/docs/event-types-v2/invalid-credential.mdx
@@ -1,0 +1,9 @@
+---
+title: "Invalid Credential"
+---
+
+import InvalidCredentialExample from '/snippets/event_model_examples/invalid_credential.mdx'
+
+The `invalid_credential` type represents a leaked credential that was checked against the tenant's identity provider integration, such as Microsoft Entra ID, and confirmed to to be invalid.
+
+<InvalidCredentialExample />

--- a/docs/event-types-v2/leaked-credential.mdx
+++ b/docs/event-types-v2/leaked-credential.mdx
@@ -1,0 +1,9 @@
+---
+title: "Leaked Credential"
+---
+
+import LeakedCredentialExample from '/snippets/event_model_examples/leaked_credential.mdx'
+
+The `leaked_credential` type represents a single leaked identity and password pair, collected from sources such as breaches and combolists circulating on illicit networks.
+
+<LeakedCredentialExample />

--- a/docs/event-types-v2/mitigated-credential.mdx
+++ b/docs/event-types-v2/mitigated-credential.mdx
@@ -1,0 +1,9 @@
+---
+title: "Mitigated Credential"
+---
+
+import MitigatedCredentialExample from '/snippets/event_model_examples/mitigated_credential.mdx'
+
+The `mitigated_credential` type represents a compromised credential for which a mitigation action, such as disabling the account or revoking its sessions, was performed through the tenant's identity provider integration.
+
+<MitigatedCredentialExample />

--- a/docs/event-types-v2/overview.mdx
+++ b/docs/event-types-v2/overview.mdx
@@ -13,10 +13,15 @@ Currently these event type models are supported on the
 | `blog_post`    | [Blog Post <Icon icon="book" size={16} />](/event-types-v2/blog-post)               |
 | `bucket`       | [Bucket <Icon icon="book" size={16} />](/event-types-v2/bucket)                     |
 | `chat_message` | [Chat Message <Icon icon="book" size={16} />](/event-types-v2/chat-message)         |
+| `credit_card` | [Chat Message <Icon icon="book" size={16} />](/event-types-v2/chat-message)         |
 | `document`     | [Ransomleak (document) <Icon icon="book" size={16} />](/event-types-v2/ransom-leak) |
 | `domain`       | [Lookalike Domain (domain) <Icon icon="book" size={16} />](/event-types-v2/domain)  |
 | `forum_post`   | [Forum Post & Topic <Icon icon="book" size={16} />](/event-types-v2/forum-post)     |
+| `invalid_credential` | [Invalid Credential <Icon icon="book" size={16} />](/event-types-v2/invalid-credential) |
+| `leaked_credential` | [Leaked Credential <Icon icon="book" size={16} />](/event-types-v2/leaked-credential) |
 | `listing`      | [Listing <Icon icon="book" size={16} />](/event-types-v2/listing)                   |
+| `mitigated_credential` | [Mitigated Credential <Icon icon="book" size={16} />](/event-types-v2/mitigated-credential) |
 | `paste`        | [Paste <Icon icon="book" size={16} />](/event-types-v2/paste)                       |
 | `stealer_log`  | [Stealer Log <Icon icon="book" size={16} />](/event-types-v2/stealer-log)           |
 | `social_media` | [Social media <Icon icon="book" size={16} />](/event-types-v2/social-media-account) |
+| `valid_credential` | [Valid Credential <Icon icon="book" size={16} />](/event-types-v2/valid-credential) |

--- a/docs/event-types-v2/valid-credential.mdx
+++ b/docs/event-types-v2/valid-credential.mdx
@@ -1,0 +1,9 @@
+---
+title: "Valid Credential"
+---
+
+import ValidCredentialExample from '/snippets/event_model_examples/valid_credential.mdx'
+
+The `valid_credential` type represents a leaked credential that was confirmed to still be valid against the tenant's identity provider integration, such as Microsoft Entra ID.
+
+<ValidCredentialExample />

--- a/docs/snippets/event_model_examples/invalid_credential.mdx
+++ b/docs/snippets/event_model_examples/invalid_credential.mdx
@@ -1,0 +1,27 @@
+{/*
+    If you are in pyro:
+    - If this file changes, you should also modify the API docs.
+    - https://github.com/flared/docs-api/
+
+    If you are in mintlify:
+    - Don't edit this directly, edit the generator in pyro.
+    - pyro/pyro/mintlify/test_firework_event_models.py
+*/}
+
+```json Invalid Credential
+{
+    "event_type": "invalid_credential",
+    "metadata": {
+        "estimated_created_at": "2025-01-01T00:00:00",
+        "flare_url": "https://app.flare.io/#/uid",
+        "matched_at": null,
+        "severity": "info",
+        "uid": "index/source/id"
+    },
+    "data": {
+        "identity_name": "john.doe@example.com",
+        "credential_hash": "a1b2c3d4e5f67890",
+        "tenant_integration_id": "00000000-0000-0000-0000-000000000001"
+    }
+}
+```

--- a/docs/snippets/event_model_examples/leaked_credential.mdx
+++ b/docs/snippets/event_model_examples/leaked_credential.mdx
@@ -1,0 +1,31 @@
+{/*
+    If you are in pyro:
+    - If this file changes, you should also modify the API docs.
+    - https://github.com/flared/docs-api/
+
+    If you are in mintlify:
+    - Don't edit this directly, edit the generator in pyro.
+    - pyro/pyro/mintlify/test_firework_event_models.py
+*/}
+
+```json Leaked Credential
+{
+    "event_type": "leaked_credential",
+    "metadata": {
+        "estimated_created_at": "2025-01-01T00:00:00",
+        "flare_url": "https://app.flare.io/#/uid",
+        "matched_at": null,
+        "severity": "info",
+        "uid": "index/source/id"
+    },
+    "data": {
+        "identity_name": "identity_name",
+        "imported_at": "2025-01-01T00:00:00",
+        "password": "password",
+        "source": {
+            "id": "url_login_pass",
+            "name": "URL Login Pass"
+        }
+    }
+}
+```

--- a/docs/snippets/event_model_examples/mitigated_credential.mdx
+++ b/docs/snippets/event_model_examples/mitigated_credential.mdx
@@ -1,0 +1,28 @@
+{/*
+    If you are in pyro:
+    - If this file changes, you should also modify the API docs.
+    - https://github.com/flared/docs-api/
+
+    If you are in mintlify:
+    - Don't edit this directly, edit the generator in pyro.
+    - pyro/pyro/mintlify/test_firework_event_models.py
+*/}
+
+```json Mitigated Credential
+{
+    "event_type": "mitigated_credential",
+    "metadata": {
+        "estimated_created_at": "2025-01-01T00:00:00",
+        "flare_url": "https://app.flare.io/#/uid",
+        "matched_at": null,
+        "severity": "info",
+        "uid": "index/source/id"
+    },
+    "data": {
+        "identity_name": "john.doe@example.com",
+        "credential_hash": "a1b2c3d4e5f67890",
+        "tenant_integration_id": "00000000-0000-0000-0000-000000000001",
+        "mitigation_action": "disable_account"
+    }
+}
+```

--- a/docs/snippets/event_model_examples/valid_credential.mdx
+++ b/docs/snippets/event_model_examples/valid_credential.mdx
@@ -1,0 +1,27 @@
+{/*
+    If you are in pyro:
+    - If this file changes, you should also modify the API docs.
+    - https://github.com/flared/docs-api/
+
+    If you are in mintlify:
+    - Don't edit this directly, edit the generator in pyro.
+    - pyro/pyro/mintlify/test_firework_event_models.py
+*/}
+
+```json Valid Credential
+{
+    "event_type": "valid_credential",
+    "metadata": {
+        "estimated_created_at": "2025-01-01T00:00:00",
+        "flare_url": "https://app.flare.io/#/uid",
+        "matched_at": null,
+        "severity": "info",
+        "uid": "index/source/id"
+    },
+    "data": {
+        "identity_name": "john.doe@example.com",
+        "credential_hash": "a1b2c3d4e5f67890",
+        "tenant_integration_id": "00000000-0000-0000-0000-000000000001"
+    }
+}
+```


### PR DESCRIPTION
Event types listed in /firework/v4/events/ response

https://github.com/user-attachments/assets/65015aef-3026-4657-854d-6fcdc380e1f0


Event types added to Events Overview page
<img width="792" height="843" alt="Screenshot 2026-07-14 at 12 46 02 PM" src="https://github.com/user-attachments/assets/3a3bdb2e-463c-4cbc-a6c7-c83e9fd46f00" />

Invalid Credential page
<img width="718" height="645" alt="Screenshot 2026-07-14 at 12 46 33 PM" src="https://github.com/user-attachments/assets/5a37f11b-fbde-4db0-8389-7968a137dae1" />

Valid credential page
<img width="691" height="621" alt="Screenshot 2026-07-14 at 12 46 49 PM" src="https://github.com/user-attachments/assets/b6facd49-2c5b-4e67-9d3f-a81eee557b56" />

Mitigated credential page
<img width="689" height="649" alt="Screenshot 2026-07-14 at 12 47 10 PM" src="https://github.com/user-attachments/assets/58f33ef1-dd81-45e9-b971-9ab638d70ddc" />
