### PR TITLE
C33 - Events - Add docs for new V2 Service Events endpoint

### DIFF
--- a/docs/api-reference/spec/firework-v4-openapi.json
+++ b/docs/api-reference/spec/firework-v4-openapi.json
@@ -439,6 +439,9 @@
                                                     "$ref": "#/components/schemas/RansomLeakEvent"
                                                 },
                                                 {
+                                                    "$ref": "#/components/schemas/ServiceEvent"
+                                                },
+                                                {
                                                     "$ref": "#/components/schemas/SocialMediaEvent"
                                                 },
                                                 {
@@ -463,6 +466,7 @@
                                                     "mitigated_credential": "#/components/schemas/MitigatedCredentialEvent",
                                                     "paste": "#/components/schemas/PasteEvent",
                                                     "ransomleak": "#/components/schemas/RansomLeakEvent",
+                                                    "service": "#/components/schemas/ServiceEvent",
                                                     "social_media_account": "#/components/schemas/SocialMediaEvent",
                                                     "stealer_log": "#/components/schemas/pyro__findings__stealerlogs__datamodels__StealerLogEvent",
                                                     "valid_credential": "#/components/schemas/ValidCredentialEvent"
@@ -9759,6 +9763,162 @@
                     "secret"
                 ],
                 "title": "SecretQuery"
+            },
+"ServiceEvent": {
+                "properties": {
+                    "event_type": {
+                        "type": "string",
+                        "const": "service",
+                        "title": "Event Type",
+                        "default": "service"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/ServiceEventData"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/EventMetadata"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "data",
+                    "metadata"
+                ],
+                "title": "Service"
+            },
+            "ServiceEventData": {
+                "properties": {
+                    "url": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Url",
+                        "description": "The URL to the service. This may be an IP address and port combination."
+                    },
+                    "asn": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Asn",
+                        "description": "The Autonomous System Number."
+                    },
+                    "content": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Content",
+                        "description": "The raw content returned by the service."
+                    },
+                    "service": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Service",
+                        "description": "The protocol of the service e.g. https"
+                    },
+                    "product": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Product",
+                        "description": "The software product that powers the service e.g. Apache httpd"
+                    },
+                    "port": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Port",
+                        "description": "The port the service listens on."
+                    },
+                    "ip_address": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Ip Address",
+                        "description": "The IP address of the service."
+                    },
+                    "organization": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Organization",
+                        "description": "The organization that manages the IP address, often a hosting provider."
+                    },
+                    "hostname": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Hostname",
+                        "description": "The hostname the service is served under."
+                    },
+                    "country_code": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Country Code",
+                        "description": "The country code of the IP address."
+                    },
+                    "vulnerabilities": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Vulnerabilities",
+                        "description": "CVE identifiers of vulnerabilities the service is potentially affected by."
+                    }
+                },
+                "type": "object",
+                "title": "ServiceEventData"
             },
             "Severity": {
                 "type": "string",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -334,6 +334,7 @@
               "event-types-v2/mitigated-credential",
               "event-types-v2/paste",
               "event-types-v2/ransom-leak",
+              "event-types-v2/service",
               "event-types-v2/social-media-account",
               "event-types-v2/stealer-log",
               "event-types-v2/valid-credential"

--- a/docs/event-types-v2/overview.mdx
+++ b/docs/event-types-v2/overview.mdx
@@ -24,4 +24,5 @@ Currently these event type models are supported on the
 | `paste`        | [Paste <Icon icon="book" size={16} />](/event-types-v2/paste)                       |
 | `stealer_log`  | [Stealer Log <Icon icon="book" size={16} />](/event-types-v2/stealer-log)           |
 | `social_media` | [Social media <Icon icon="book" size={16} />](/event-types-v2/social-media-account) |
+| `service`      | [Service <Icon icon="book" size={16} />](/event-types-v2/service)               |
 | `valid_credential` | [Valid Credential <Icon icon="book" size={16} />](/event-types-v2/valid-credential) |

--- a/docs/event-types-v2/service.mdx
+++ b/docs/event-types-v2/service.mdx
@@ -1,0 +1,14 @@
+---
+title: "Service"
+---
+
+import ServiceExample from '/snippets/event_model_examples/service.mdx'
+
+The `service` type represents an internet-exposed service, such as a web server listening on a public IP address.
+
+Each record corresponds to a single host and port combination and may include:
+- Network details (IP address, port, hostname, ASN, country, and the organization managing the IP).
+- Protocol and product (for example `https` served by Apache httpd), plus a URL and raw response content when available.
+- CVE identifiers of vulnerabilities the service may be affected by.
+
+<ServiceExample />

--- a/docs/snippets/event_model_examples/service.mdx
+++ b/docs/snippets/event_model_examples/service.mdx
@@ -1,0 +1,37 @@
+{/*
+    If you are in pyro:
+    - If this file changes, you should also modify the API docs.
+    - https://github.com/flared/docs-api/
+
+    If you are in mintlify:
+    - Don't edit this directly, edit the generator in pyro.
+    - pyro/pyro/mintlify/test_firework_event_models.py
+*/}
+
+```json Service
+{
+    "event_type": "service",
+    "data": {
+        "url": "https://www.example.com",
+        "asn": "AS64496",
+        "content": "<!DOCTYPE html>\n<html>\n<head>\n    <title>Example Domain</title>\n</head>\n<body>\n    <h1>Example Domain</h1>\n</body>\n</html>",
+        "service": "https",
+        "product": "Apache httpd",
+        "port": 443,
+        "ip_address": "192.0.2.10",
+        "organization": "Example Hosting Inc.",
+        "hostname": "www.example.com",
+        "country_code": "US",
+        "vulnerabilities": [
+            "CVE-2021-41773"
+        ]
+    },
+    "metadata": {
+        "estimated_created_at": "2025-01-01T00:00:00",
+        "flare_url": "https://app.flare.io/#/uid",
+        "matched_at": null,
+        "severity": "info",
+        "uid": "index/source/id"
+    }
+}
+```


### PR DESCRIPTION
Event types listed in /firework/v4/events/ response
<img width="1486" height="856" alt="Screenshot 2026-07-20 at 5 37 11 PM" src="https://github.com/user-attachments/assets/dce93b06-5ca8-4506-9a1e-dd82859b003a" />



Event types added to Events Overview page
<img width="670" height="617" alt="Screenshot 2026-07-20 at 5 36 22 PM" src="https://github.com/user-attachments/assets/27fce29c-5b01-45ef-82ab-19348cd113fc" />


Service Events page: 
<img width="525" height="701" alt="Screenshot 2026-07-20 at 5 36 07 PM" src="https://github.com/user-attachments/assets/649d3797-a163-4be8-8bc6-973a6096aa1c" />
