### PR TITLE
C33 - MCP - Update the MCP API doc with information about global search quota

### DIFF
--- a/docs/concepts/rate-limits-and-quotas.mdx
+++ b/docs/concepts/rate-limits-and-quotas.mdx
@@ -34,7 +34,7 @@ If you receive 429 errors, Flare's recommended course of action is to wait 10 se
 
 
 ## Quotas
-API users are responsible for monitoring their Global Search usage and ensuring it remains within their allocated monthly quota.
+API and MCP users are responsible for monitoring their Global Search usage and ensuring it remains within their allocated monthly quota.
 
 Users with account administration rights can also view their Global Search monthly usage by logging into the platform and navigating to [the tenants page](https://app.flare.io/#/tenants).
 

--- a/docs/sdk/api-mcp.mdx
+++ b/docs/sdk/api-mcp.mdx
@@ -27,7 +27,9 @@ themselves), see the
 | `profile_get`                  | Returns the current user's profile, including tenants, permissions, feature flags, and default tenant id.                       |
 
 <Note>
-  `search_global` requires the Global Search permission on the target tenant.
+  `search_global` requires the Global Search permission on the target tenant. In addition, calls to the `search_global` will use Global Search credits.
+
+  For additional information, please refer to [Global Search Quota](https://docs.flare.io/global-search-quota).
 </Note>
 
 ### Search Parameters

--- a/docs/sdk/api-mcp.mdx
+++ b/docs/sdk/api-mcp.mdx
@@ -27,7 +27,7 @@ themselves), see the
 | `profile_get`                  | Returns the current user's profile, including tenants, permissions, feature flags, and default tenant id.                       |
 
 <Note>
-  `search_global` requires the Global Search permission on the target tenant, and each call counts against the tenant's monthly Global Search quota.
+  `search_global` requires the Global Search permission on the target tenant. Each call counts against the tenant's monthly Global Search quota.
 
   For additional information, please refer to [Global Search Quota](https://docs.flare.io/global-search-quota).
 </Note>

--- a/docs/sdk/api-mcp.mdx
+++ b/docs/sdk/api-mcp.mdx
@@ -27,7 +27,7 @@ themselves), see the
 | `profile_get`                  | Returns the current user's profile, including tenants, permissions, feature flags, and default tenant id.                       |
 
 <Note>
-  `search_global` requires the Global Search permission on the target tenant. In addition, calls to the `search_global` will use Global Search credits.
+  `search_global` requires the Global Search permission on the target tenant, and each call counts against the tenant's monthly Global Search quota.
 
   For additional information, please refer to [Global Search Quota](https://docs.flare.io/global-search-quota).
 </Note>


### PR DESCRIPTION
Added mentioned of the global search quota
<img width="791" height="701" alt="Screenshot 2026-07-22 at 4 17 13 PM" src="https://github.com/user-attachments/assets/fe746af8-f45d-4692-885f-eb68add456d8" />


<img width="474" height="394" alt="Screenshot 2026-07-22 at 4 02 33 PM" src="https://github.com/user-attachments/assets/a3f4e120-cb95-4857-857d-759e69152a13" />
