### PR TITLE
Add status param to events feed endpoint

### DIFF
--- a/docs/snippets/endpoint-event-search-common.mdx
+++ b/docs/snippets/endpoint-event-search-common.mdx
@@ -242,11 +242,21 @@ This endpoint supports the
       If provided, results will be filtered on the tags.
     </ParamField>
 
-    <ParamField body="is_ignored" type="bool">
+    <ParamField body="status" type="string[]">
+      If provided, results will only contain events that match one of the specified statuses.
+
+      <Expandable title="valid status values">
+        `open`
+        `ignored`
+        `remediated`
+      </Expandable>
+    </ParamField>
+
+    <ParamField body="is_ignored" type="bool" deprecated>
       If set to true, results will be filtered to be events that have been ignored.
     </ParamField>
 
-    <ParamField body="is_remediated" type="bool">
+    <ParamField body="is_remediated" type="bool" deprecated>
       If set to true, results will be filtered to be events that have been remediated.
     </ParamField>
   </Expandable>


### PR DESCRIPTION
Preview of the changes:
<img width="531" height="453" alt="Screenshot 2026-08-03 at 5 21 29 PM" src="https://github.com/user-attachments/assets/aee1b904-89ad-48d8-b909-29eb7b13d16c" />

It should be displayed on these 3 endpoints:
- https://api.docs.flare.io/api-reference/v4/endpoints/current-tenant-feed
- https://api.docs.flare.io/api-reference/v4/endpoints/identifier-feed
- https://api.docs.flare.io/api-reference/v4/endpoints/identifier-group-feed