### PR TITLE
Added Flare CTI gated access to entity endpoints

### DIFF
--- a/docs/api-reference/v4/endpoints/public/get-entity.mdx
+++ b/docs/api-reference/v4/endpoints/public/get-entity.mdx
@@ -2,3 +2,7 @@
 openapi: firework-v4-openapi get /firework/v4/entities/{id}
 tag: "BETA"
 ---
+
+import GatedAccessFeature from '/snippets/gated-access-feature.mdx';
+
+<GatedAccessFeature name="Flare CTI" />

--- a/docs/api-reference/v4/endpoints/public/list-entities.mdx
+++ b/docs/api-reference/v4/endpoints/public/list-entities.mdx
@@ -2,3 +2,7 @@
 openapi: firework-v4-openapi post /firework/v4/entities/global/_search
 tag: "BETA"
 ---
+
+import GatedAccessFeature from '/snippets/gated-access-feature.mdx';
+
+<GatedAccessFeature name="Flare CTI" />

--- a/docs/api-reference/v4/endpoints/public/list-entity-relations.mdx
+++ b/docs/api-reference/v4/endpoints/public/list-entity-relations.mdx
@@ -2,3 +2,7 @@
 openapi: firework-v4-openapi get /firework/v4/entities/{id}/relations
 tag: "BETA"
 ---
+
+import GatedAccessFeature from '/snippets/gated-access-feature.mdx';
+
+<GatedAccessFeature name="Flare CTI" />


### PR DESCRIPTION
Added a notice in the entity endpoints telling users they need the `Flare CTI` module to be able to access these endpoints.

https://github.com/user-attachments/assets/20201735-5f6a-4ddd-819b-615aeb87226d

