### PR TITLE
add threat flow custom intel doc

### DIFF
--- a/docs/api-reference/spec/firework-v4-openapi.json
+++ b/docs/api-reference/spec/firework-v4-openapi.json
@@ -293,6 +293,92 @@
                 }
             }
         },
+        "/firework/v4/threat_flow/intel/requests": {
+            "post": {
+                "tags": [
+                    "public"
+                ],
+                "summary": "Create Intel Request",
+                "description": "Queue a Custom Intel generation. Returns a `request_id` to poll with `GET /threat_flow/intel/requests/{id}`. Generation typically takes 10 to 15 minutes. A tenant may have at most 10 requests in flight at once.",
+                "operationId": "create_intel_request_threat_flow_intel_requests_post",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateIntelRequestPayload"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CreateIntelRequestResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/firework/v4/threat_flow/intel/requests/{id}": {
+            "get": {
+                "tags": [
+                    "public"
+                ],
+                "summary": "Get Intel Request",
+                "description": "Poll a Custom Intel request. `status` is `pending` then `processing` until the report is ready, then `completed` or `error`. `result.current_step` tracks the generation progress. Once `status` is `completed`, retrieve the report itself with `GET /threat_flow/reports/{result.report_id}`.",
+                "operationId": "get_intel_request_threat_flow_intel_requests__id__get",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/IntelRequestResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/firework/v4/credentials/global/_search": {
             "post": {
                 "tags": [
@@ -460,13 +546,13 @@
             }
         },
         "/firework/v4/entities/{id}/relations": {
-            "get": {
+            "post": {
                 "tags": [
                     "public",
                     "team=data-intelligence"
                 ],
                 "summary": "List Entity Relations",
-                "operationId": "list_entity_relations_entities__id__relations_get",
+                "operationId": "list_entity_relations_entities__id__relations_post",
                 "parameters": [
                     {
                         "name": "id",
@@ -477,54 +563,17 @@
                             "format": "uuid",
                             "title": "Id"
                         }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 1000,
-                            "default": 10,
-                            "title": "Size"
-                        }
-                    },
-                    {
-                        "name": "from_",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "From "
-                        }
-                    },
-                    {
-                        "name": "entity_types",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/EntityType"
-                                    }
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Entity Types"
-                        }
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EntityRelationsSearchParamsPayload"
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "200": {
                         "description": "Successful Response",
@@ -1098,6 +1147,12 @@
                                         },
                                         {
                                             "$ref": "#/components/schemas/PaginatedResults_FeedItem_str_"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/PaginatedResultsWithTotalCount_LeakedFile_str_"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/PaginatedResults_LeakedFileExtension_str_"
                                         }
                                     ],
                                     "title": "Response Expand Event Field Events  Expand Get"
@@ -2630,6 +2685,7 @@
                     "public"
                 ],
                 "summary": "Create Report Request",
+                "description": "Deprecated. Use `/firework/v4/threat_flow/intel/requests` instead, which generates the same Custom Intel as the Flare web application. The response shape differs because the underlying product differs. This endpoint will be removed; reports already generated through it stay available in the Flare application and through the Threat Flow reports endpoints.",
                 "operationId": "create_report_request_threat_flow_reports_requests_post",
                 "requestBody": {
                     "content": {
@@ -2662,7 +2718,8 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true
             }
         },
         "/firework/v4/threat_flow/reports/requests/{request_info_id}": {
@@ -2671,7 +2728,9 @@
                     "public"
                 ],
                 "summary": "Get Report Request",
+                "description": "Deprecated. Use `/firework/v4/threat_flow/intel/requests` instead, which generates the same Custom Intel as the Flare web application. The response shape differs because the underlying product differs. This endpoint will be removed; reports already generated through it stay available in the Flare application and through the Threat Flow reports endpoints.",
                 "operationId": "get_report_request_threat_flow_reports_requests__request_info_id__get",
+                "deprecated": true,
                 "parameters": [
                     {
                         "name": "request_info_id",
@@ -3010,7 +3069,6 @@
                     "forum_category",
                     "forum_post",
                     "forum_profile",
-                    "forum_thread_summary",
                     "forum_topic",
                     "host",
                     "intelligence_object",
@@ -3920,6 +3978,35 @@
                 ],
                 "title": "AssetRelationType"
             },
+            "AstpCookiesReadValue": {
+                "properties": {
+                    "cookie_names": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Cookie Names",
+                        "description": "The cookie names to monitor"
+                    },
+                    "match_subdomains": {
+                        "type": "boolean",
+                        "title": "Match Subdomains",
+                        "description": "Whether this policy will be applied to monitor subdomains of the assigned domain identifiers",
+                        "default": false
+                    },
+                    "match_prefix": {
+                        "type": "boolean",
+                        "title": "Match Prefix",
+                        "description": "Whether the cookie names are matched as prefixes rather than exactly. Read-only: it cannot be set through this API.",
+                        "default": false
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "cookie_names"
+                ],
+                "title": "AstpCookiesReadValue"
+            },
             "AstpCookiesValue": {
                 "properties": {
                     "cookie_names": {
@@ -3953,6 +4040,16 @@
                 },
                 "type": "object",
                 "title": "AstpDomainValue"
+            },
+            "AsyncRequestStatus": {
+                "type": "string",
+                "enum": [
+                    "pending",
+                    "processing",
+                    "completed",
+                    "error"
+                ],
+                "title": "AsyncRequestStatus"
             },
             "AttackPatternEntityAPIResponse": {
                 "properties": {
@@ -5435,6 +5532,37 @@
                 ],
                 "title": "CreateIncludedKeywordsBody"
             },
+            "CreateIntelRequestPayload": {
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "title": "Question"
+                    },
+                    "tone": {
+                        "$ref": "#/components/schemas/IntelTone",
+                        "default": "analytical"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "question"
+                ],
+                "title": "CreateIntelRequestPayload"
+            },
+            "CreateIntelRequestResponse": {
+                "properties": {
+                    "request_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Request Id"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "request_id"
+                ],
+                "title": "CreateIntelRequestResponse"
+            },
             "CreateLuceneQueryBody": {
                 "properties": {
                     "name": {
@@ -6219,6 +6347,16 @@
                 ],
                 "title": "DomainStatus"
             },
+            "DownloadRequestStatus": {
+                "type": "string",
+                "enum": [
+                    "not_requested",
+                    "pending",
+                    "completed",
+                    "failed"
+                ],
+                "title": "DownloadRequestStatus"
+            },
             "EmailData": {
                 "properties": {
                     "type": {
@@ -6485,6 +6623,52 @@
                 ],
                 "title": "EntityMetadataAPIResponse"
             },
+            "EntityRelationsSearchFilters": {
+                "properties": {
+                    "types": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/EntityType"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Types"
+                    }
+                },
+                "type": "object",
+                "title": "EntityRelationsSearchFilters"
+            },
+            "EntityRelationsSearchParamsPayload": {
+                "properties": {
+                    "filters": {
+                        "$ref": "#/components/schemas/EntityRelationsSearchFilters"
+                    },
+                    "from": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "From"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "maximum": 1000.0,
+                        "title": "Size",
+                        "default": 10
+                    }
+                },
+                "type": "object",
+                "title": "EntityRelationsSearchParamsPayload"
+            },
             "EntitySearchFilters": {
                 "properties": {
                     "types": {
@@ -6739,7 +6923,9 @@
                 "enum": [
                     "credentials",
                     "cookies",
-                    "associated_events"
+                    "associated_events",
+                    "leaked_files",
+                    "leaked_file_extensions"
                 ],
                 "title": "ExpandableField"
             },
@@ -9597,6 +9783,201 @@
                 ],
                 "title": "InfrastructureEntityLiteData"
             },
+            "IntelRequestPayloadResponse": {
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "title": "Question"
+                    },
+                    "tone": {
+                        "$ref": "#/components/schemas/IntelTone"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "question",
+                    "tone"
+                ],
+                "title": "IntelRequestPayloadResponse"
+            },
+            "IntelRequestProgress": {
+                "properties": {
+                    "report_id": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Report Id",
+                        "description": "The ID of the Custom Intel associated with the request"
+                    },
+                    "current_step": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/IntelRequestStep"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The current step of the request"
+                    },
+                    "iteration": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iteration",
+                        "description": "The number of iterations of the data collection process"
+                    },
+                    "events_retrieved_count": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Events Retrieved Count",
+                        "description": "The number of events retrieved from the decomposed queries search"
+                    },
+                    "generated_queries": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Generated Queries",
+                        "description": "The queries generated from the topic for the data collection process"
+                    },
+                    "triage_events_analyzed_count": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Triage Events Analyzed Count",
+                        "description": "The number of events analyzed (used to track progress of the triage process)"
+                    },
+                    "triage_events_total_count": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Triage Events Total Count",
+                        "description": "The total number of events in the triage process"
+                    },
+                    "avg_relevance_score": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg Relevance Score",
+                        "description": "The average relevance score of the triaged events"
+                    },
+                    "web_search_queries": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Web Search Queries",
+                        "description": "The queries used for web search"
+                    }
+                },
+                "type": "object",
+                "title": "IntelRequestProgress"
+            },
+            "IntelRequestResponse": {
+                "properties": {
+                    "request_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Request Id"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/AsyncRequestStatus"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At"
+                    },
+                    "request_payload": {
+                        "$ref": "#/components/schemas/IntelRequestPayloadResponse"
+                    },
+                    "result": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/IntelRequestProgress"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "request_id",
+                    "status",
+                    "created_at",
+                    "request_payload",
+                    "result"
+                ],
+                "title": "IntelRequestResponse"
+            },
+            "IntelRequestStep": {
+                "type": "string",
+                "enum": [
+                    "dark_web_collection",
+                    "triage",
+                    "ai_analysis",
+                    "clear_web_enrichment",
+                    "report_generation",
+                    "output_delivery"
+                ],
+                "title": "IntelRequestStep"
+            },
+            "IntelTone": {
+                "type": "string",
+                "enum": [
+                    "executive",
+                    "analytical"
+                ],
+                "title": "IntelTone"
+            },
             "IntelType": {
                 "type": "string",
                 "enum": [
@@ -9923,6 +10304,139 @@
                     "unignore"
                 ],
                 "title": "LeakedCredentialsBulkActionType"
+            },
+            "LeakedFile": {
+                "properties": {
+                    "uid": {
+                        "type": "string",
+                        "title": "Uid"
+                    },
+                    "filepath": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Filepath"
+                    },
+                    "filename": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Filename"
+                    },
+                    "size": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Size"
+                    },
+                    "created_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Created At"
+                    },
+                    "first_crawled_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "First Crawled At"
+                    },
+                    "archive_file": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Archive File"
+                    },
+                    "archive_type": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Archive Type"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/DownloadRequestStatus"
+                    },
+                    "is_requesting_user": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Is Requesting User"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "uid",
+                    "filepath",
+                    "filename",
+                    "size",
+                    "created_at",
+                    "first_crawled_at",
+                    "archive_file",
+                    "archive_type",
+                    "status",
+                    "is_requesting_user"
+                ],
+                "title": "LeakedFile"
+            },
+            "LeakedFileExtension": {
+                "properties": {
+                    "extension": {
+                        "type": "string",
+                        "title": "Extension"
+                    },
+                    "description": {
+                        "type": "string",
+                        "title": "Description"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "extension",
+                    "description"
+                ],
+                "title": "LeakedFileExtension"
             },
             "ListingEvent": {
                 "properties": {
@@ -10568,7 +11082,7 @@
                         "description": "The type of the matching policy"
                     },
                     "value": {
-                        "$ref": "#/components/schemas/PolicyValue",
+                        "$ref": "#/components/schemas/PolicyReadValue",
                         "description": "The value of the matching policy depending on its type"
                     },
                     "created_at": {
@@ -10725,6 +11239,45 @@
                     "desc"
                 ],
                 "title": "OrderType"
+            },
+            "PaginatedResultsWithTotalCount_LeakedFile_str_": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/LeakedFile"
+                        },
+                        "type": "array",
+                        "title": "Items"
+                    },
+                    "next": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next"
+                    },
+                    "total_count": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Count"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items",
+                    "next"
+                ],
+                "title": "PaginatedResultsWithTotalCount[LeakedFile, str]"
             },
             "PaginatedResults_Alert_str_": {
                 "properties": {
@@ -10893,6 +11446,34 @@
                     "next"
                 ],
                 "title": "PaginatedResults[GlobalFeedItem, str]"
+            },
+            "PaginatedResults_LeakedFileExtension_str_": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/LeakedFileExtension"
+                        },
+                        "type": "array",
+                        "title": "Items"
+                    },
+                    "next": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items",
+                    "next"
+                ],
+                "title": "PaginatedResults[LeakedFileExtension, str]"
             },
             "PaginatedResults_MatchingPolicyPayload_str_": {
                 "properties": {
@@ -11374,6 +11955,22 @@
                     "identifier_ids"
                 ],
                 "title": "PolicyAssignmentsBody"
+            },
+            "PolicyReadValue": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/KeywordsValue"
+                    },
+                    {
+                        "$ref": "#/components/schemas/LuceneValue"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AstpCookiesReadValue"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AstpDomainValue"
+                    }
+                ]
             },
             "PolicyValue": {
                 "anyOf": [

--- a/docs/api-reference/v4/endpoints/create-intel-request.mdx
+++ b/docs/api-reference/v4/endpoints/create-intel-request.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: firework-v4-openapi get /firework/v4/threat_flow/reports/{report_id}
+openapi: firework-v4-openapi post /firework/v4/threat_flow/intel/requests
 ---
 
 import GatedAccessFeature from '/snippets/gated-access-feature.mdx';

--- a/docs/api-reference/v4/endpoints/create-report-request.mdx
+++ b/docs/api-reference/v4/endpoints/create-report-request.mdx
@@ -2,7 +2,11 @@
 openapi: firework-v4-openapi post /firework/v4/threat_flow/reports/requests
 ---
 
-## Guides
+<Warning>
+**DEPRECATED:** This endpoint should be replaced by
+[/firework/v4/threat_flow/intel/requests <Icon icon="code" size={16} />](/api-reference/v4/endpoints/create-intel-request)
+</Warning>
 
-See the guide for using this endpoint:
-[Generate a Threat Flow Report <Icon icon="book" size={16} />](/guides/threat-flow-report).
+import GatedAccessFeature from '/snippets/gated-access-feature.mdx';
+
+<GatedAccessFeature name="Flare CTI" />

--- a/docs/api-reference/v4/endpoints/get-intel-request.mdx
+++ b/docs/api-reference/v4/endpoints/get-intel-request.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: firework-v4-openapi get /firework/v4/threat_flow/reports/{report_id}
+openapi: firework-v4-openapi get /firework/v4/threat_flow/intel/requests/{id}
 ---
 
 import GatedAccessFeature from '/snippets/gated-access-feature.mdx';

--- a/docs/api-reference/v4/endpoints/get-report-request.mdx
+++ b/docs/api-reference/v4/endpoints/get-report-request.mdx
@@ -2,7 +2,11 @@
 openapi: firework-v4-openapi get /firework/v4/threat_flow/reports/requests/{request_info_id}
 ---
 
-## Guides
+<Warning>
+**DEPRECATED:** This endpoint should be replaced by
+[/firework/v4/threat_flow/intel/requests/\{id\} <Icon icon="code" size={16} />](/api-reference/v4/endpoints/get-intel-request)
+</Warning>
 
-See the guide for using this endpoint:
-[Generate a Threat Flow Report <Icon icon="book" size={16} />](/guides/threat-flow-report).
+import GatedAccessFeature from '/snippets/gated-access-feature.mdx';
+
+<GatedAccessFeature name="Flare CTI" />

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -246,10 +246,11 @@
             "group": "Threat-Flow API",
             "pages": [
               {
-                "group": "Reports",
+                "group": "Custom Intel",
                 "pages": [
-                  "api-reference/v4/endpoints/create-report-request",
-                  "api-reference/v4/endpoints/get-report-request"
+                  "api-reference/v4/endpoints/create-intel-request",
+                  "api-reference/v4/endpoints/get-intel-request",
+                  "api-reference/v4/endpoints/get-report"
                 ]
               }
             ]
@@ -296,6 +297,13 @@
                   "api-reference/v3/endpoints/identifiers/get-fireworkv3identifiers-1",
                   "api-reference/v2/endpoints/identifiers/delete-fireworkv2assets",
                   "api-reference/v2/endpoints/identifiers/post-fireworkv2assets-toggle"
+                ]
+              },
+              {
+                "group": "Threat-Flow Reports",
+                "pages": [
+                  "api-reference/v4/endpoints/create-report-request",
+                  "api-reference/v4/endpoints/get-report-request"
                 ]
               }
             ]

--- a/docs/guides/threat-flow-report.mdx
+++ b/docs/guides/threat-flow-report.mdx
@@ -2,28 +2,38 @@
 title: "Generate a Threat Flow Report"
 ---
 
+import GatedAccessFeature from '/snippets/gated-access-feature.mdx';
+
+<GatedAccessFeature name="Flare CTI" />
+
 <Steps>
 
-  <Step title="Create a report request">
+  <Step title="Create an intel request">
     Use the
-    [threat_flow/reports/request <Icon icon="code" size={16} />](/api-reference/v4/endpoints/create-report-request)
-    endpoint to create a new report request.
+    [threat_flow/intel/requests <Icon icon="code" size={16} />](/api-reference/v4/endpoints/create-intel-request)
+    endpoint to queue the generation of a report for a given question.
 
-    This endpoint returns an id that can be used to fetch the report when it is ready.
+    This endpoint returns a `request_id` that can be used to poll the request until it is completed.
   </Step>
 
-  <Step title="Verify for the report's status">
+  <Step title="Poll the intel request">
     Use the
-    [/threat_flow/reports/\{report_id\} <Icon icon="code" size={16} />](/api-reference/v4/endpoints/get-report)
-    endpoint to verify the status.
+    [threat_flow/intel/requests/\{id\} <Icon icon="code" size={16} />](/api-reference/v4/endpoints/get-intel-request)
+    endpoint to poll the request's status.
 
-    If the report is ready, this endpoint will return an object with the `status` property set to `completed`.
+    Generation typically takes 10 to 15 minutes. While the request is in progress, `status` will be
+    `pending` or `processing`. Once it is done, `status` will be `completed` and `result.report_id`
+    will contain the id of the generated report, or `status` will be `error` if generation failed.
 
-    If the report is not yet completed, wait 5 seconds and call this endpoint again.
+    If the request is not yet completed, wait a few seconds and call this endpoint again.
   </Step>
 
-  <Step title="Access the report">
-    On success, access the `report` property of the previous response to view the report.
+  <Step title="Get the report">
+    Use the
+    [threat_flow/reports/\{report_id\} <Icon icon="code" size={16} />](/api-reference/v4/endpoints/get-report)
+    endpoint with the `result.report_id` from the previous step to retrieve the finished report.
+
+    On success, access the `report` property of the response to view the report.
   </Step>
 
 </Steps>
@@ -39,48 +49,50 @@ This is an end-to-end example in Python.
 import json
 import time
 
-from datetime import datetime
-from datetime import timedelta
 from flareio import FlareApiClient
 
 
 api_client = FlareApiClient.from_env()
 
-# Create a report request
-report_request_resp = api_client.post(
-    "/firework/v4/threat_flow/reports/requests",
+# Create an intel request
+intel_request_resp = api_client.post(
+    "/firework/v4/threat_flow/intel/requests",
     json={
-        "report_title": f"XSS report - {datetime.now().isoformat()}",
         "question": "xss vulnerability in banks",
-        "time_range_type": "last_1m",
-        "included_keywords": ["xss"],
-        "excluded_keywords": ["canada"],
+        "tone": "analytical",
     },
 )
-report_request_resp.raise_for_status()
-request_id: str = report_request_resp.json()["request_id"]
-print(f"Created report request: {request_id=}")
+intel_request_resp.raise_for_status()
+request_id: str = intel_request_resp.json()["request_id"]
+print(f"Created intel request: {request_id=}")
 
-# Wait for the report to be completed
-timeout = datetime.now() + timedelta(minutes=5)
-while datetime.now() < timeout:
-    report_resp = api_client.get(
-        f"/firework/v4/threat_flow/reports/requests/{request_id}",
+# Poll the intel request until it's completed
+report_id: int | None = None
+timeout = time.monotonic() + 60 * 15
+while time.monotonic() < timeout:
+    intel_resp = api_client.get(
+        f"/firework/v4/threat_flow/intel/requests/{request_id}",
     )
-    report_resp.raise_for_status()
-    report_status = report_resp.json()["status"]
+    intel_resp.raise_for_status()
+    intel_data = intel_resp.json()
+    status = intel_data["status"]
 
-    if report_status == "completed":
+    if status == "completed":
+        report_id = intel_data["result"]["report_id"]
         break
-    elif report_status != "processing":
-        raise Exception(f"Unexpected report status: {report_status=}")
+    elif status == "error":
+        raise Exception(f"Intel request failed: {intel_data=}")
 
-    print("Waiting for report to be completed...")
+    print(f"Waiting for intel request to complete ({status=})...")
     time.sleep(5)
 else:
-    raise Exception("Failed to create report within 5 minutes")
+    raise Exception("Failed to complete intel request within 15 minutes")
 
-# Display the report
+# Fetch the finished report
+report_resp = api_client.get(
+    f"/firework/v4/threat_flow/reports/{report_id}",
+)
+report_resp.raise_for_status()
 report: dict = report_resp.json()["report"]
 print("Report:")
 print(json.dumps(report, indent=4))


### PR DESCRIPTION
Add documentation for new Custom intel endpoints (post intel request, get intel request, get threat flow report)
Deprecate old threat flow endpoints

## New endpoints
<img width="2060" height="1108" alt="image" src="https://github.com/user-attachments/assets/427a5014-7dfa-4219-a9b6-2a77abfe6f8e" />
<img width="1959" height="1187" alt="image" src="https://github.com/user-attachments/assets/1fe78c99-08df-40a8-93e6-f460aecdd60e" />

## Guide
<img width="1068" height="1112" alt="image" src="https://github.com/user-attachments/assets/85929e50-2e78-40e4-ba84-603c25d91421" />


## Deprecated endpoints
<img width="1774" height="782" alt="image" src="https://github.com/user-attachments/assets/6a373ae9-486e-491f-be10-e8abd1bce5ca" />
<img width="1793" height="830" alt="image" src="https://github.com/user-attachments/assets/f3c2306e-102a-45a4-bdf8-2662b15b8e98" />
