### PR TITLE
Add Sandbox API to docs.json

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,9 +15,7 @@
         "groups": [
           {
             "group": "Introduction",
-            "pages": [
-              "introduction/getting-started"
-            ]
+            "pages": ["introduction/getting-started"]
           },
           {
             "group": "Base Concepts",
@@ -40,9 +38,7 @@
           },
           {
             "group": "Advanced",
-            "pages": [
-              "advanced/event-source-filters"
-            ]
+            "pages": ["advanced/event-source-filters"]
           },
           {
             "group": "Guides",
@@ -124,9 +120,7 @@
               },
               {
                 "group": "Cookies",
-                "pages": [
-                  "api-reference/astp/endpoints/post-cookies-search"
-                ]
+                "pages": ["api-reference/astp/endpoints/post-cookies-search"]
               }
             ]
           },
@@ -255,6 +249,10 @@
             ]
           },
           {
+            "group": "Sandbox API",
+            "pages": ["api-reference/v4/endpoints/create-presigned-upload-url"]
+          },
+          {
             "group": "Deprecated APIs",
             "pages": [
               {
@@ -367,9 +365,7 @@
         "groups": [
           {
             "group": "Changelog",
-            "pages": [
-              "changelog/overview"
-            ]
+            "pages": ["changelog/overview"]
           }
         ]
       }
@@ -398,9 +394,7 @@
       "display": "interactive"
     },
     "mdx": {
-      "server": [
-        "https://api.flare.io/"
-      ],
+      "server": ["https://api.flare.io/"],
       "auth": {
         "method": "bearer"
       }


### PR DESCRIPTION
I may or may not have forgotten to include this in the docs.json when I was releasing the feature 🫣 

<img width="1919" height="964" alt="Screenshot 2026-08-21 at 1 47 10 PM" src="https://github.com/user-attachments/assets/5a3f4df5-c6b1-4514-8e09-e7c563252f6f" />
