### PR TITLE
Change Log - Add Entry For August 2026

### DIFF
--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -12,6 +12,10 @@ This page lists changes to Flare's API.
 Release notes for the Flare Platform can be found on the [product documentation website](https://docs.flare.io/releases).
 </Note>
 
+<Update label="2026-08" description="API - August 2026">
+  Added a new [Create Presigned Upload URL Endpoint <Icon icon="code" size={16} />](/api-reference/v4/endpoints/create-presigned-upload-url) to upload files for later submission to Sandbox for analysis.
+</Update>
+
 <Update label="2026-07" description="API - July 2026">
   Released the [Flare API MCP server (beta) <Icon icon="book" size={16} />](/sdk/api-mcp).
 


### PR DESCRIPTION
I had to sit with this one a little longer because it wasn't already done compared to the page 😬 

<img width="1919" height="963" alt="Screenshot 2026-08-21 at 2 30 28 PM" src="https://github.com/user-attachments/assets/5fd3e2ab-83ca-4d10-87c5-f3f8b2a24dac" />
